### PR TITLE
[Feat] 퀴즈 중단 확인 모달 UI 구현

### DIFF
--- a/src/pages/article/QuizExitModal.tsx
+++ b/src/pages/article/QuizExitModal.tsx
@@ -1,0 +1,108 @@
+// TODO: 라우팅 설정 후 QuizExitModal.tsx의 폴더상 위치 바꾸기
+
+// TODO: 폴더 구조 설정 후 XIcon 위치 바꾸기
+import React, { useEffect, useRef, useState } from 'react';
+
+const XIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path d="M18 6L6 18" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+        <path d="M6 6L18 18" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+    </svg>
+);
+
+interface Props {
+    onClose: () => void;
+    onContinue: () => void;
+    onExit: () => void;
+}
+
+// TODO: 아래 코드는 임시 기본 핸들러
+// 라우팅 설정 후 실제 로직으로 변경하기
+const DummyQuizExitModal = () => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    const handleClose = () => {
+        console.log('모달 닫기');
+        setIsOpen(false);
+    };
+
+    const handleContinue = () => {
+        alert('퀴즈 이어풀기');
+        setIsOpen(false);
+    };
+
+    const handleExit = () => {
+        alert('퀴즈 중단하기');
+        setIsOpen(false);
+    };
+
+    if (!isOpen) return null;
+
+    return <QuizExitModal onClose={handleClose} onContinue={handleContinue} onExit={handleExit} />;
+};
+
+const QuizExitModal: React.FC<Props> = ({ onClose, onContinue, onExit }) => {
+    const modalRef = useRef<HTMLDivElement>(null);
+
+    // ESC 키로 닫기
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [onClose]);
+
+    // 바깥 클릭 시 닫기
+    const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+            onClose();
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleOverlayClick}>
+            <div ref={modalRef} className="relative h-[350px] w-[350px] rounded-[9.375px] bg-white shadow-md">
+                {/* 닫기 버튼 */}
+                <button
+                    className="absolute top-[8px] right-[8px] flex h-[22px] w-[22px] cursor-pointer items-center justify-center"
+                    onClick={onClose}
+                >
+                    <XIcon className="text-black-70" />
+                </button>
+
+                {/* 문구 */}
+                <div className="text-28px-semibold absolute top-[35px] left-1/2 h-[126px] w-[245px] -translate-x-1/2">
+                    잠깐, <br />
+                    아직 풀지 못한 문제가 <br />
+                    남았어요!
+                </div>
+
+                {/* 브라우저 해상도, 기기에 따라 버튼 border 굵기가 1px로 반올림되어 렌더링될 수 있음 */}
+                {/* 이어풀기 */}
+                <button
+                    onClick={onContinue}
+                    className="border-black-50 absolute top-[209px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px]"
+                >
+                    <span className="text-18px-medium text-black-70">이어풀기</span>
+                </button>
+
+                {/* 중단하기 */}
+                <button
+                    onClick={onExit}
+                    className="border-black-50 absolute top-[273px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px]"
+                >
+                    <span className="text-18px-medium text-black-70">중단하기</span>
+                </button>
+            </div>
+        </div>
+    );
+};
+
+// 임시 export:
+export default DummyQuizExitModal;
+
+// TODO: 실제 사용 시 밑의 코드로 변경하기
+// export default QuizExitModal;

--- a/src/shared/assets/icons/close-x.svg
+++ b/src/shared/assets/icons/close-x.svg
@@ -1,4 +1,3 @@
-<svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M11.6562 1.59375L0.71875 12.5312M0.71875 1.59375L11.6562 12.5312" stroke="black" stroke-opacity="0.7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M11.6562 1.59375L0.71875 12.5312M0.71875 1.59375L11.6562 12.5312" stroke="black" stroke-opacity="0.2" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 8L8 24M8 8L24 24" stroke="#1E1E1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/shared/assets/icons/close-x.svg
+++ b/src/shared/assets/icons/close-x.svg
@@ -1,0 +1,4 @@
+<svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.6562 1.59375L0.71875 12.5312M0.71875 1.59375L11.6562 12.5312" stroke="black" stroke-opacity="0.7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.6562 1.59375L0.71875 12.5312M0.71875 1.59375L11.6562 12.5312" stroke="black" stroke-opacity="0.2" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -1,12 +1,6 @@
-// TODO: 폴더 구조 설정 후 XIcon 위치 바꾸기
 import React, { useEffect, useRef, useState } from 'react';
 
-const XIcon = (props: React.SVGProps<SVGSVGElement>) => (
-    <svg width={24} height={24} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-        <path d="M18 6L6 18" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
-        <path d="M6 6L18 18" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
-    </svg>
-);
+import XIcon from './icons/close-x.svg';
 
 interface Props {
     onClose: () => void;
@@ -68,7 +62,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
                     className="absolute top-[8px] right-[8px] flex h-[22px] w-[22px] cursor-pointer items-center justify-center"
                     onClick={onClose}
                 >
-                    <XIcon className="text-black-70" />
+                    <XIcon />
                 </button>
 
                 {/* 문구 */}

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -1,5 +1,3 @@
-// TODO: 라우팅 설정 후 QuizExitModal.tsx의 폴더상 위치 바꾸기
-
 // TODO: 폴더 구조 설정 후 XIcon 위치 바꾸기
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -41,7 +39,7 @@ const DummyQuizExitModal = () => {
     return <QuizExitModal onClose={handleClose} onContinue={handleContinue} onExit={handleExit} />;
 };
 
-const QuizExitModal: React.FC<Props> = ({ onClose, onContinue, onExit }) => {
+function QuizExitModal({ onClose, onContinue, onExit }: Props) {
     const modalRef = useRef<HTMLDivElement>(null);
 
     // ESC 키로 닫기
@@ -99,7 +97,7 @@ const QuizExitModal: React.FC<Props> = ({ onClose, onContinue, onExit }) => {
             </div>
         </div>
     );
-};
+}
 
 // 임시 export:
 export default DummyQuizExitModal;

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import XIcon from '@/shared/assets/icons/close-x.svg?react';
 
-interface Props {
+interface QuizExitModalProps {
     onClose: () => void;
     onContinue: () => void;
     onExit: () => void;
@@ -33,7 +33,7 @@ const DummyQuizExitModal = () => {
     return <QuizExitModal onClose={handleClose} onContinue={handleContinue} onExit={handleExit} />;
 };
 
-function QuizExitModal({ onClose, onContinue, onExit }: Props) {
+const QuizExitModal = ({ onClose, onContinue, onExit }: QuizExitModalProps) => {
     const modalRef = useRef<HTMLDivElement>(null);
 
     // ESC 키로 닫기
@@ -87,7 +87,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
             </div>
         </div>
     );
-}
+};
 
 // 임시 export:
 export default DummyQuizExitModal;

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -58,7 +58,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleOverlayClick}>
             <div ref={modalRef} className="relative h-[350px] w-[350px] rounded-[9.375px] bg-white shadow-md">
                 {/* 닫기 버튼 */}
-                <button onClick={onClose} className="absolute top-3 right-3">
+                <button onClick={onClose} className="absolute top-3 right-3 cursor-pointer">
                     <XIcon />
                 </button>
 
@@ -69,21 +69,20 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
                     남았어요!
                 </div>
 
-                {/* 브라우저 해상도, 기기에 따라 버튼 border 굵기가 1px로 반올림되어 렌더링될 수 있음 */}
                 {/* 이어풀기 */}
                 <button
                     onClick={onContinue}
-                    className="border-black-50 absolute top-[209px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px]"
+                    className="border-black-50 hover:bg-main text-black-70 absolute top-[209px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px] hover:border-none hover:text-white"
                 >
-                    <span className="text-18px-medium text-black-70">이어풀기</span>
+                    <span className="text-18px-medium group-hover:text-white">이어풀기</span>
                 </button>
 
                 {/* 중단하기 */}
                 <button
                     onClick={onExit}
-                    className="border-black-50 absolute top-[273px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px]"
+                    className="border-black-50 text-black-70 hover:bg-danger/90 absolute top-[273px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px] hover:border-none hover:text-white"
                 >
-                    <span className="text-18px-medium text-black-70">중단하기</span>
+                    <span className="text-18px-medium group-hover:text-white">중단하기</span>
                 </button>
             </div>
         </div>

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -58,7 +58,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleOverlayClick}>
             <div ref={modalRef} className="relative h-[350px] w-[350px] rounded-[10px] bg-white shadow-md">
                 {/* 닫기 버튼 */}
-                <button onClick={onClose} className="absolute top-3 right-3 cursor-pointer">
+                <button onClick={onClose} className="absolute top-[12px] right-[8px] cursor-pointer">
                     <XIcon />
                 </button>
 

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -80,7 +80,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
                 {/* 중단하기 */}
                 <button
                     onClick={onExit}
-                    className="border-black-50 text-black-70 hover:bg-danger/90 absolute top-[273px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px] hover:border-none hover:text-white"
+                    className="border-black-50 text-black-70 hover:bg-danger absolute top-[273px] left-1/2 flex h-[40px] w-[240px] -translate-x-1/2 cursor-pointer items-center justify-center rounded-[5px] border border-[0.63px] hover:border-none hover:text-white"
                 >
                     <span className="text-18px-medium group-hover:text-white">중단하기</span>
                 </button>

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import XIcon from './icons/close-x.svg';
+import XIcon from '@/shared/assets/icons/close-x.svg?react';
 
 interface Props {
     onClose: () => void;
@@ -58,10 +58,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleOverlayClick}>
             <div ref={modalRef} className="relative h-[350px] w-[350px] rounded-[9.375px] bg-white shadow-md">
                 {/* 닫기 버튼 */}
-                <button
-                    className="absolute top-[8px] right-[8px] flex h-[22px] w-[22px] cursor-pointer items-center justify-center"
-                    onClick={onClose}
-                >
+                <button onClick={onClose} className="absolute top-3 right-3">
                     <XIcon />
                 </button>
 

--- a/src/shared/components/QuizExitModal.tsx
+++ b/src/shared/components/QuizExitModal.tsx
@@ -56,7 +56,7 @@ function QuizExitModal({ onClose, onContinue, onExit }: Props) {
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={handleOverlayClick}>
-            <div ref={modalRef} className="relative h-[350px] w-[350px] rounded-[9.375px] bg-white shadow-md">
+            <div ref={modalRef} className="relative h-[350px] w-[350px] rounded-[10px] bg-white shadow-md">
                 {/* 닫기 버튼 */}
                 <button onClick={onClose} className="absolute top-3 right-3 cursor-pointer">
                     <XIcon />


### PR DESCRIPTION
## 📌 Summary
- close #54 
- 퀴즈 도중 중단하려 할 때 노출되는 확인 모달 UI 구현
- ESC 키 또는 바깥 클릭 시 모달 닫힘 처리 포함

## 📝 Tasks
- `QuizExitModal.tsx` 컴포넌트 구현 (props: `onClose`, `onContinue`, `onExit`)
- ESC 키 입력 이벤트로 모달 닫기 처리
- 오버레이 클릭 시 닫기 처리
- 닫기 버튼(X) SVG 컴포넌트(`XIcon`) 임시 정의
- 이어풀기 / 중단하기 버튼 UI 구현
- 피그마 기준에 맞춘 모달 정중앙 배치 및 반응형 대응
- 테스트용 임시 컴포넌트 `DummyQuizExitModal` 작성

## ✅ PR Checklist (To Reviewer)
- [ ] Figma UI 기준과 실제 모달 디자인이 일치하는지 확인
- [ ] ESC 키 및 바깥 클릭 시 닫힘 기능 동작 확인 
- [ ] 버튼 클릭 시 각 핸들러(`onContinue`, `onExit`)가 정상 작동하는지 확인
- [ ] 향후 `XIcon` 및 `QuizExitModal` 위치 리팩토링 예정인 점 감안
## 📸 Screenshot
<img width="400" alt="image" src="https://github.com/user-attachments/assets/43b5f2f1-68e1-4acc-a559-e7725fec3c2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a modal dialog that alerts users about unfinished quiz questions, allowing them to choose to continue or exit the quiz. The modal can be closed by clicking outside or pressing Escape.

* **Style**
  * Added visually distinct modal styling with centered positioning, rounded corners, and shadow effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->