### PR TITLE
[Feat] 간추린 뉴스 박스 UI 구현

### DIFF
--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,12 +1,9 @@
-import FontTest from '../FontTest';
+import SummerizedNews from '@/shared/components/SummarizedNews/SummarizedNews';
 
 const HomePage = () => {
     return (
-        <div className="flex min-h-screen items-center justify-center">
-            {/* TODO: FontTest는 임시로 넣은 컴포넌트입니다. 추후 삭제 예정입니다. */}
-            {/* <h1 className="text-4xl font-bold">홈 페이지</h1> */}
-            <FontTest />
-            <p className="mt-4 text-lg">actions sync 확인</p>
+        <div className="home-page">
+            <SummerizedNews />
         </div>
     );
 };

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,11 +1,5 @@
-import SummerizedNews from '@/shared/components/SummarizedNews/SummarizedNews';
-
 const HomePage = () => {
-    return (
-        <div className="home-page">
-            <SummerizedNews />
-        </div>
-    );
+    return <div className="home-page"></div>;
 };
 
 export default HomePage;

--- a/src/shared/assets/Bookmark.svg
+++ b/src/shared/assets/Bookmark.svg
@@ -1,0 +1,3 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.5 21.5L12.5 16.5L5.5 21.5V5.5C5.5 4.96957 5.71071 4.46086 6.08579 4.08579C6.46086 3.71071 6.96957 3.5 7.5 3.5H17.5C18.0304 3.5 18.5391 3.71071 18.9142 4.08579C19.2893 4.46086 19.5 4.96957 19.5 5.5V21.5Z" stroke="#B3B3B3" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/assets/Rectangle105.svg
+++ b/src/shared/assets/Rectangle105.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.101562" y="0.402344" width="21.1963" height="21.1963" fill="#0557E0"/>
+</svg>

--- a/src/shared/assets/Share.svg
+++ b/src/shared/assets/Share.svg
@@ -1,0 +1,3 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.5 12.5V20.5C4.5 21.0304 4.71071 21.5391 5.08579 21.9142C5.46086 22.2893 5.96957 22.5 6.5 22.5H18.5C19.0304 22.5 19.5391 22.2893 19.9142 21.9142C20.2893 21.5391 20.5 21.0304 20.5 20.5V12.5M16.5 6.5L12.5 2.5M12.5 2.5L8.5 6.5M12.5 2.5V15.5" stroke="#B3B3B3" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/components/SummarizedNews/SummarizedNews.tsx
+++ b/src/shared/components/SummarizedNews/SummarizedNews.tsx
@@ -6,7 +6,7 @@ const SummarizedNews = () => {
     const newsContent =
         '간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 ';
     return (
-        <div className="relative top-[291px] left-[120px] flex w-[690px] flex-col rounded-[30px] border-[3px] border-[rgba(5,87,224,0.3)] bg-white px-[30px] pt-[30px] pb-[28px]">
+        <div className="border-main-30 relative top-[291px] left-[120px] flex w-[690px] flex-col rounded-[30px] border-[3px] bg-white px-[30px] pt-[30px] pb-[28px]">
             <div className="flex justify-between">
                 <div className="flex space-x-[8px]">
                     <RectangleIcon />
@@ -17,7 +17,7 @@ const SummarizedNews = () => {
                     <ShareIcon />
                 </div>
             </div>
-            <div className="text-18px-medium mt-[5px] break-words text-gray-900">{newsContent}</div>
+            <div className="text-18px-medium text-black-70 mt-[5px] break-words">{newsContent}</div>
         </div>
     );
 };

--- a/src/shared/components/SummarizedNews/SummarizedNews.tsx
+++ b/src/shared/components/SummarizedNews/SummarizedNews.tsx
@@ -1,0 +1,25 @@
+import BookMarkIcon from '@/shared/assets/Bookmark.svg?react';
+import RectangleIcon from '@/shared/assets/Rectangle105.svg?react';
+import ShareIcon from '@/shared/assets/Share.svg?react';
+
+const SummarizedNews = () => {
+    const newsContent =
+        '간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 ';
+    return (
+        <div className="relative top-[291px] left-[120px] flex w-[690px] flex-col rounded-[30px] border-[3px] border-[rgba(5,87,224,0.3)] bg-white px-[30px] pt-[30px] pb-[28px]">
+            <div className="flex justify-between">
+                <div className="flex space-x-[8px]">
+                    <RectangleIcon />
+                    <span className="text-28px-semibold relative top-[-10px] text-black">간추린 뉴스</span>
+                </div>
+                <div className="flex gap-[21px]">
+                    <BookMarkIcon />
+                    <ShareIcon />
+                </div>
+            </div>
+            <div className="text-18px-medium mt-[5px] break-words text-gray-900">{newsContent}</div>
+        </div>
+    );
+};
+
+export default SummarizedNews;

--- a/src/shared/components/SummarizedNewsContainer/SummarizedNewsContainer.tsx
+++ b/src/shared/components/SummarizedNewsContainer/SummarizedNewsContainer.tsx
@@ -2,7 +2,7 @@ import BookMarkIcon from '@/shared/assets/Bookmark.svg?react';
 import RectangleIcon from '@/shared/assets/Rectangle105.svg?react';
 import ShareIcon from '@/shared/assets/Share.svg?react';
 
-const SummarizedNews = () => {
+const SummarizedNewsContainer = () => {
     const newsContent =
         '간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 간추린뉴스 내용 ';
     return (
@@ -22,4 +22,4 @@ const SummarizedNews = () => {
     );
 };
 
-export default SummarizedNews;
+export default SummarizedNewsContainer;


### PR DESCRIPTION
## 📌 Summary
- close #65 


## 📝 Tasks
- 간추린 뉴스 박스 UI 구현
- 피그마와 잘 맞는지 확인 부탁드립니다
- 피그마에서는 각 줄마다 회색 선이 있는데 어려워서 일단 뒀습니다..찾아보니 랜더링 시에는 얼마나 긴 텍스트가 올지 고려하지 않아서 줄바꿈 수에 맞게 회색 선을 추가하는 것이 힘든 것 같습니다. 저희가 실제로 백에서 받아올 때 줄바꿈을 고려해야 가능한 것으로 보입니다. 



## ✅ PR Checklist (To Reviewer)
- 


## 📸 Screenshot
<img width="1129" height="417" alt="image" src="https://github.com/user-attachments/assets/f9ec9efd-ffd5-4d1a-838e-c8a5df66bb85" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a summarized news container displaying a header with icons and a section for summarized news content.

* **Refactor**
  * Simplified the HomePage layout by removing additional components and content, leaving only the main container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->