### PR TITLE
[Feat] Accordion UI 제작 및 용어집 테스트 완료

### DIFF
--- a/src/assets/CloseButton.svg
+++ b/src/assets/CloseButton.svg
@@ -1,0 +1,4 @@
+<svg width="23" height="22" viewBox="0 0 23 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6562 5.59375L5.71875 16.5312M5.71875 5.59375L16.6562 16.5312" stroke="black" stroke-opacity="0.7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6562 5.59375L5.71875 16.5312M5.71875 5.59375L16.6562 16.5312" stroke="black" stroke-opacity="0.2" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/chevronIcon.svg
+++ b/src/assets/chevronIcon.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="24" viewBox="0 0 30 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.5 9L15 15L22.5 9" stroke="black" stroke-opacity="0.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/snackIcon.svg
+++ b/src/assets/snackIcon.svg
@@ -1,0 +1,91 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1467_12771)">
+<g filter="url(#filter0_i_1467_12771)">
+<rect x="13.5332" y="4.78711" width="25.4516" height="19.0816" rx="4.84533" transform="rotate(45 13.5332 4.78711)" fill="#E09749"/>
+</g>
+<g filter="url(#filter1_f_1467_12771)">
+<rect x="13.5332" y="4.92416" width="25.2578" height="17.9042" rx="4.74842" transform="rotate(45 13.5332 4.92416)" stroke="#E6A966" stroke-width="0.193813"/>
+</g>
+<g filter="url(#filter2_di_1467_12771)">
+<rect x="14.332" y="5.58398" width="23.1972" height="16.7639" rx="4.41615" transform="rotate(45 14.332 5.58398)" fill="#E9E2DC"/>
+</g>
+<rect x="13.2432" y="24.4473" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 13.2432 24.4473)" fill="#B1A9A2"/>
+<rect x="6.57324" y="17.7793" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 6.57324 17.7793)" fill="#B1A9A2"/>
+<rect x="15.2051" y="26.4121" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 15.2051 26.4121)" fill="#B1A9A2"/>
+<rect x="17.1455" y="28.3516" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 17.1455 28.3516)" fill="#B1A9A2"/>
+<rect x="8.62305" y="19.8281" width="8.55533" height="5.20833" rx="0.52282" transform="rotate(-45 8.62305 19.8281)" fill="#55ACEE"/>
+<rect x="18.1621" y="0.158203" width="25.4516" height="17.7585" rx="4.84533" transform="rotate(45 18.1621 0.158203)" fill="#4B311E" fill-opacity="0.8"/>
+<g filter="url(#filter3_i_1467_12771)">
+<rect x="18.4023" y="-0.0820312" width="25.4516" height="17.7585" rx="4.84533" transform="rotate(45 18.4023 -0.0820312)" fill="#F3A756"/>
+</g>
+<circle cx="20.2324" cy="5.25566" r="0.278837" transform="rotate(45 20.2324 5.25566)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="23.8311" cy="8.85332" r="0.278837" transform="rotate(45 23.8311 8.85332)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="27.4287" cy="12.4529" r="0.278837" transform="rotate(45 27.4287 12.4529)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="31.0273" cy="16.0506" r="0.278837" transform="rotate(45 31.0273 16.0506)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="16.2402" cy="5.6502" r="0.278837" transform="rotate(45 16.2402 5.6502)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="19.8389" cy="9.24785" r="0.278837" transform="rotate(45 19.8389 9.24785)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="23.4365" cy="12.8475" r="0.278837" transform="rotate(45 23.4365 12.8475)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="27.0352" cy="16.4451" r="0.278837" transform="rotate(45 27.0352 16.4451)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="30.6338" cy="20.0428" r="0.278837" transform="rotate(45 30.6338 20.0428)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="15.8457" cy="9.64238" r="0.278837" transform="rotate(45 15.8457 9.64238)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="19.4443" cy="13.24" r="0.278837" transform="rotate(45 19.4443 13.24)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="23.042" cy="16.8396" r="0.278837" transform="rotate(45 23.042 16.8396)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="26.6406" cy="20.4373" r="0.278837" transform="rotate(45 26.6406 20.4373)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="11.8535" cy="10.0369" r="0.278837" transform="rotate(45 11.8535 10.0369)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="15.4521" cy="13.6346" r="0.278837" transform="rotate(45 15.4521 13.6346)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="19.0498" cy="17.2342" r="0.278837" transform="rotate(45 19.0498 17.2342)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="22.6484" cy="20.8318" r="0.278837" transform="rotate(45 22.6484 20.8318)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="26.2471" cy="24.4295" r="0.278837" transform="rotate(45 26.2471 24.4295)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="11.459" cy="14.0291" r="0.278837" transform="rotate(45 11.459 14.0291)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="15.0576" cy="17.6268" r="0.278837" transform="rotate(45 15.0576 17.6268)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="18.6553" cy="21.2264" r="0.278837" transform="rotate(45 18.6553 21.2264)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="22.2539" cy="24.824" r="0.278837" transform="rotate(45 22.2539 24.824)" fill="#4B0C00" fill-opacity="0.37"/>
+</g>
+<defs>
+<filter id="filter0_i_1467_12771" x="2.04785" y="5.92276" width="27.4756" height="28.3468" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.872159"/>
+<feGaussianBlur stdDeviation="0.494223"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.286275 0 0 0 0 0.129412 0 0 0 0 0.0313726 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_1467_12771"/>
+</filter>
+<filter id="filter1_f_1467_12771" x="2.6246" y="6.67636" width="27.0174" height="27.0164" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.0592827" result="effect1_foregroundBlur_1467_12771"/>
+</filter>
+<filter id="filter2_di_1467_12771" x="3.72618" y="6.35419" width="25.7605" height="26.239" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="0.193813" operator="dilate" in="SourceAlpha" result="effect1_dropShadow_1467_12771"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="0.193813"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.242307 0 0 0 0 0.113707 0 0 0 0 0.0431028 0 0 0 0.8 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1467_12771"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1467_12771" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.41317"/>
+<feGaussianBlur stdDeviation="0.529937"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.819608 0 0 0 0 0.8 0 0 0 0 0.776471 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_1467_12771"/>
+</filter>
+<filter id="filter3_i_1467_12771" x="7.85254" y="0.762903" width="26.54" height="27.7019" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.5505"/>
+<feGaussianBlur stdDeviation="0.581439"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.372549 0 0 0 0 0.172549 0 0 0 0 0.0627451 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_1467_12771"/>
+</filter>
+<clipPath id="clip0_1467_12771">
+<rect x="18.0391" y="0.203125" width="25" height="25" rx="5.2282" transform="rotate(45 18.0391 0.203125)" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/pages/test/AccordionTestPage.tsx
+++ b/src/pages/test/AccordionTestPage.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+import { Accordion, glossaryTestData } from '../../shared/components/Accordion';
+
+const AccordionTestPage: React.FC = () => {
+    const [glossaryExpanded, setGlossaryExpanded] = useState(false);
+
+    return (
+        <div className="min-h-screen p-8">
+            <div className="mx-auto max-w-4xl">
+                <div className="grid grid-cols-1 gap-8">
+                    {/* 용어집 테스트 */}
+                    <div className="space-y-4">
+                        <Accordion
+                            title="용어집"
+                            data={glossaryTestData}
+                            isExpanded={glossaryExpanded}
+                            onToggle={() => setGlossaryExpanded(!glossaryExpanded)}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default AccordionTestPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ const CustomFeedPage = lazy(() => import('@/pages/custom-feed/CustomFeedPage'));
 const SearchPage = lazy(() => import('@/pages/search/SearchPage'));
 const PasswordChangePage = lazy(() => import('@/pages/password-change/PasswordChangePage'));
 const DeleteAccountPage = lazy(() => import('@/pages/delete-account/DeleteAccountPage'));
+const AccordionTestPage = lazy(() => import('@/pages/test/AccordionTestPage'));
 
 const routes: RouteObject[] = [
     {
@@ -81,6 +82,14 @@ const routes: RouteObject[] = [
                 element: (
                     <Suspense fallback={<LoadingFallback />}>
                         <SearchPage />
+                    </Suspense>
+                ),
+            },
+            {
+                path: 'accordion-test',
+                element: (
+                    <Suspense fallback={<LoadingFallback />}>
+                        <AccordionTestPage />
                     </Suspense>
                 ),
             },

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -29,11 +29,11 @@ const Accordion: React.FC<AccordionProps> = ({ title, data, isExpanded = false, 
             <div className="flex w-full justify-center">
                 <button
                     onClick={onToggle}
-                    className="flex w-full items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
+                    className="flex w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
                 >
-                    <span className="text-sm">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
+                    <span className="text-14px-medium">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
                     <span className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
-                        <ChevronIcon width={14} />
+                        <ChevronIcon width={15} />
                     </span>
                 </button>
             </div>

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -1,0 +1,44 @@
+//통합 아코디언 컴포넌트
+import React from 'react';
+
+import ChevronIcon from '@/assets/chevronIcon.svg?react';
+import SnackIcon from '@/assets/snackIcon.svg?react';
+
+import type { AccordionProps } from '../../types/accordionTypes';
+import GlossaryContent from './GlossaryContent';
+
+const Accordion: React.FC<AccordionProps> = ({ title, data, isExpanded = false, onToggle }) => {
+    return (
+        <div className="max-w-md rounded-lg border border-blue-200 bg-white p-6">
+            {/* 헤더 */}
+            <div className="mb-4 flex flex-col items-start space-x-3">
+                <div className="mb-2 flex items-center space-x-2">
+                    <SnackIcon />
+                    <h3 className="text-lg font-bold text-black">{title}</h3>
+                </div>
+                <p className="mt-1 text-sm text-black">이 기사의 핵심 어휘들을 살펴보아요.</p>
+            </div>
+
+            {/* 구분선 */}
+            <div className="mb-4 border-t border-gray-300"></div>
+
+            {/* 컨텐츠(용어집) */}
+            {isExpanded && <GlossaryContent data={data} />}
+
+            {/* 토글 버튼 */}
+            <div className="flex w-full justify-center">
+                <button
+                    onClick={onToggle}
+                    className="flex w-full items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
+                >
+                    <span className="text-sm">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
+                    <span className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                        <ChevronIcon width={14} />
+                    </span>
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default Accordion;

--- a/src/shared/components/Accordion/GlossaryContent.tsx
+++ b/src/shared/components/Accordion/GlossaryContent.tsx
@@ -1,0 +1,24 @@
+//용어집 Content
+import React from 'react';
+
+import type { GlossaryItem } from '../../types/accordionTypes';
+
+interface GlossaryContentProps {
+    data: GlossaryItem[];
+}
+
+const GlossaryContent: React.FC<GlossaryContentProps> = ({ data }) => {
+    return (
+        <div className="mb-4 space-y-3">
+            {data.map((item, index) => (
+                <div key={item.word} className="space-y-1">
+                    <div className="text-main text-sm font-bold text-black">{item.word}</div>
+                    <div className="mb-2 text-sm text-black">{item.definition}</div>
+                    {index < data.length - 1 && <div className="border-t border-gray-300"></div>}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default GlossaryContent;

--- a/src/shared/components/Accordion/GlossaryContent.tsx
+++ b/src/shared/components/Accordion/GlossaryContent.tsx
@@ -9,12 +9,12 @@ interface GlossaryContentProps {
 
 const GlossaryContent: React.FC<GlossaryContentProps> = ({ data }) => {
     return (
-        <div className="mb-4 space-y-3">
+        <div className="mb-4 space-y-3 rounded-2xl border-1 border-gray-300 bg-white p-6">
             {data.map((item, index) => (
                 <div key={item.word} className="space-y-1">
                     <div className="text-main text-sm font-bold text-black">{item.word}</div>
                     <div className="mb-2 text-sm text-black">{item.definition}</div>
-                    {index < data.length - 1 && <div className="border-t border-gray-300"></div>}
+                    {index < data.length - 1 && <div className="border-b border-gray-300"></div>}
                 </div>
             ))}
         </div>

--- a/src/shared/components/Accordion/index.ts
+++ b/src/shared/components/Accordion/index.ts
@@ -1,0 +1,3 @@
+export { default as Accordion } from './Accordion';
+export { default as GlossaryContent } from './GlossaryContent';
+export { glossaryTestData } from './testData';

--- a/src/shared/components/Accordion/testData.ts
+++ b/src/shared/components/Accordion/testData.ts
@@ -1,0 +1,28 @@
+//테스트를 위해 임시로 만든 데이터입니다!
+import type { GlossaryItem } from '../../types/accordionTypes';
+
+// 용어집 테스트 데이터
+export const glossaryTestData: GlossaryItem[] = [
+    {
+        word: '안녕',
+        definition: '한국말로 인사 >_<',
+    },
+    {
+        word: '펭귄',
+        definition: '귀여워요',
+    },
+    {
+        word: '마라탕',
+        definition: '배고파요',
+    },
+    {
+        word: '과자',
+        definition: '맛있당',
+    },
+    {
+        word: '스낵',
+        definition: '화이팅🍀',
+    },
+];
+
+// API 연결 후에는 받아오는 데이터로 대체될 예정입니다.

--- a/src/shared/types/accordionTypes.ts
+++ b/src/shared/types/accordionTypes.ts
@@ -1,0 +1,11 @@
+export interface GlossaryItem {
+    word: string;
+    definition: string;
+}
+
+export interface AccordionProps {
+    title: string;
+    data: GlossaryItem[];
+    isExpanded?: boolean;
+    onToggle?: () => void;
+}


### PR DESCRIPTION
## 📌 Summary
- close #72 

## 📝 Tasks
- [ ] 용어집 아코디언 컴포넌트 구현
- [ ] 테스트 페이지에서 용어집 기능만 테스트 가능하도록 구현


## ✅ PR Checklist (To Reviewer)
- [ ] 단어가 잘 보이는지 확인

접어두기/펼쳐두기 버튼과 단어(Contents) 부분 border가 다른 이유는 만들어봤는데 눈에 잘 띄지 않더라구요..! 이게 더 깔끔한 것 같아서 바꿔봤습니다! 이상하면 바로 수정할게요!


## 📸 Screenshot
<img width="1010" height="1118" alt="image" src="https://github.com/user-attachments/assets/08ee94ff-244d-47cc-8d47-d76d380ebe69" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an Accordion component for displaying expandable content.
  * Added a Glossary view with sample glossary items in an accordion format.
  * Added a dedicated test page to preview and interact with the Accordion feature.
  * New route available for accessing the Accordion test page.

* **Chores**
  * Added temporary sample glossary data for demonstration purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->