### PR TITLE
[Feat] 아코디언 용어집 및 퀴즈 UI 완료

### DIFF
--- a/src/assets/CloseButton.svg
+++ b/src/assets/CloseButton.svg
@@ -1,0 +1,4 @@
+<svg width="23" height="22" viewBox="0 0 23 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6562 5.59375L5.71875 16.5312M5.71875 5.59375L16.6562 16.5312" stroke="black" stroke-opacity="0.7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6562 5.59375L5.71875 16.5312M5.71875 5.59375L16.6562 16.5312" stroke="black" stroke-opacity="0.2" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/chevronIcon.svg
+++ b/src/assets/chevronIcon.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="24" viewBox="0 0 30 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.5 9L15 15L22.5 9" stroke="black" stroke-opacity="0.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/snackIcon.svg
+++ b/src/assets/snackIcon.svg
@@ -1,0 +1,91 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1467_12771)">
+<g filter="url(#filter0_i_1467_12771)">
+<rect x="13.5332" y="4.78711" width="25.4516" height="19.0816" rx="4.84533" transform="rotate(45 13.5332 4.78711)" fill="#E09749"/>
+</g>
+<g filter="url(#filter1_f_1467_12771)">
+<rect x="13.5332" y="4.92416" width="25.2578" height="17.9042" rx="4.74842" transform="rotate(45 13.5332 4.92416)" stroke="#E6A966" stroke-width="0.193813"/>
+</g>
+<g filter="url(#filter2_di_1467_12771)">
+<rect x="14.332" y="5.58398" width="23.1972" height="16.7639" rx="4.41615" transform="rotate(45 14.332 5.58398)" fill="#E9E2DC"/>
+</g>
+<rect x="13.2432" y="24.4473" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 13.2432 24.4473)" fill="#B1A9A2"/>
+<rect x="6.57324" y="17.7793" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 6.57324 17.7793)" fill="#B1A9A2"/>
+<rect x="15.2051" y="26.4121" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 15.2051 26.4121)" fill="#B1A9A2"/>
+<rect x="17.1455" y="28.3516" width="6.88085" height="1.45072" rx="0.72536" transform="rotate(-45 17.1455 28.3516)" fill="#B1A9A2"/>
+<rect x="8.62305" y="19.8281" width="8.55533" height="5.20833" rx="0.52282" transform="rotate(-45 8.62305 19.8281)" fill="#55ACEE"/>
+<rect x="18.1621" y="0.158203" width="25.4516" height="17.7585" rx="4.84533" transform="rotate(45 18.1621 0.158203)" fill="#4B311E" fill-opacity="0.8"/>
+<g filter="url(#filter3_i_1467_12771)">
+<rect x="18.4023" y="-0.0820312" width="25.4516" height="17.7585" rx="4.84533" transform="rotate(45 18.4023 -0.0820312)" fill="#F3A756"/>
+</g>
+<circle cx="20.2324" cy="5.25566" r="0.278837" transform="rotate(45 20.2324 5.25566)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="23.8311" cy="8.85332" r="0.278837" transform="rotate(45 23.8311 8.85332)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="27.4287" cy="12.4529" r="0.278837" transform="rotate(45 27.4287 12.4529)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="31.0273" cy="16.0506" r="0.278837" transform="rotate(45 31.0273 16.0506)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="16.2402" cy="5.6502" r="0.278837" transform="rotate(45 16.2402 5.6502)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="19.8389" cy="9.24785" r="0.278837" transform="rotate(45 19.8389 9.24785)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="23.4365" cy="12.8475" r="0.278837" transform="rotate(45 23.4365 12.8475)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="27.0352" cy="16.4451" r="0.278837" transform="rotate(45 27.0352 16.4451)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="30.6338" cy="20.0428" r="0.278837" transform="rotate(45 30.6338 20.0428)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="15.8457" cy="9.64238" r="0.278837" transform="rotate(45 15.8457 9.64238)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="19.4443" cy="13.24" r="0.278837" transform="rotate(45 19.4443 13.24)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="23.042" cy="16.8396" r="0.278837" transform="rotate(45 23.042 16.8396)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="26.6406" cy="20.4373" r="0.278837" transform="rotate(45 26.6406 20.4373)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="11.8535" cy="10.0369" r="0.278837" transform="rotate(45 11.8535 10.0369)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="15.4521" cy="13.6346" r="0.278837" transform="rotate(45 15.4521 13.6346)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="19.0498" cy="17.2342" r="0.278837" transform="rotate(45 19.0498 17.2342)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="22.6484" cy="20.8318" r="0.278837" transform="rotate(45 22.6484 20.8318)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="26.2471" cy="24.4295" r="0.278837" transform="rotate(45 26.2471 24.4295)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="11.459" cy="14.0291" r="0.278837" transform="rotate(45 11.459 14.0291)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="15.0576" cy="17.6268" r="0.278837" transform="rotate(45 15.0576 17.6268)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="18.6553" cy="21.2264" r="0.278837" transform="rotate(45 18.6553 21.2264)" fill="#4B0C00" fill-opacity="0.37"/>
+<circle cx="22.2539" cy="24.824" r="0.278837" transform="rotate(45 22.2539 24.824)" fill="#4B0C00" fill-opacity="0.37"/>
+</g>
+<defs>
+<filter id="filter0_i_1467_12771" x="2.04785" y="5.92276" width="27.4756" height="28.3468" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.872159"/>
+<feGaussianBlur stdDeviation="0.494223"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.286275 0 0 0 0 0.129412 0 0 0 0 0.0313726 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_1467_12771"/>
+</filter>
+<filter id="filter1_f_1467_12771" x="2.6246" y="6.67636" width="27.0174" height="27.0164" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.0592827" result="effect1_foregroundBlur_1467_12771"/>
+</filter>
+<filter id="filter2_di_1467_12771" x="3.72618" y="6.35419" width="25.7605" height="26.239" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="0.193813" operator="dilate" in="SourceAlpha" result="effect1_dropShadow_1467_12771"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="0.193813"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.242307 0 0 0 0 0.113707 0 0 0 0 0.0431028 0 0 0 0.8 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1467_12771"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1467_12771" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.41317"/>
+<feGaussianBlur stdDeviation="0.529937"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.819608 0 0 0 0 0.8 0 0 0 0 0.776471 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_1467_12771"/>
+</filter>
+<filter id="filter3_i_1467_12771" x="7.85254" y="0.762903" width="26.54" height="27.7019" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-1.5505"/>
+<feGaussianBlur stdDeviation="0.581439"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.372549 0 0 0 0 0.172549 0 0 0 0 0.0627451 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_1467_12771"/>
+</filter>
+<clipPath id="clip0_1467_12771">
+<rect x="18.0391" y="0.203125" width="25" height="25" rx="5.2282" transform="rotate(45 18.0391 0.203125)" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/pages/test/AccordionTestPage.tsx
+++ b/src/pages/test/AccordionTestPage.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+import { Accordion, glossaryTestData } from '../../shared/components/Accordion';
+
+const AccordionTestPage: React.FC = () => {
+    const [glossaryExpanded, setGlossaryExpanded] = useState(false);
+
+    return (
+        <div className="min-h-screen p-8">
+            <div className="mx-auto max-w-4xl">
+                <div className="grid grid-cols-1 gap-8">
+                    {/* 용어집 테스트 */}
+                    <div className="space-y-4">
+                        <Accordion
+                            title="용어집"
+                            data={glossaryTestData}
+                            isExpanded={glossaryExpanded}
+                            onToggle={() => setGlossaryExpanded(!glossaryExpanded)}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default AccordionTestPage;

--- a/src/pages/test/AccordionTestPage.tsx
+++ b/src/pages/test/AccordionTestPage.tsx
@@ -1,21 +1,30 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
-import { Accordion, glossaryTestData } from '../../shared/components/Accordion';
+import Accordion from '@/shared/components/Accordion/Accordion';
+import { glossaryTestData, quizData } from '@/shared/components/Accordion/testData';
 
-const AccordionTestPage: React.FC = () => {
+const AccordionTestPage = () => {
     const [glossaryExpanded, setGlossaryExpanded] = useState(false);
+    const [quizExpanded, setQuizExpanded] = useState(false);
 
     return (
         <div className="min-h-screen p-8">
             <div className="mx-auto max-w-4xl">
-                <div className="grid grid-cols-1 gap-8">
-                    {/* 용어집 테스트 */}
+                <div className="grid grid-cols-2 gap-8">
                     <div className="space-y-4">
                         <Accordion
                             title="용어집"
                             data={glossaryTestData}
                             isExpanded={glossaryExpanded}
-                            onToggle={() => setGlossaryExpanded(!glossaryExpanded)}
+                            onToggle={() => setGlossaryExpanded((prev) => !prev)}
+                        />
+                    </div>
+                    <div className="space-y-4">
+                        <Accordion
+                            title="퀴즈"
+                            data={quizData}
+                            isExpanded={quizExpanded}
+                            onToggle={() => setQuizExpanded((prev) => !prev)}
                         />
                     </div>
                 </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ const CustomFeedPage = lazy(() => import('@/pages/custom-feed/CustomFeedPage'));
 const SearchPage = lazy(() => import('@/pages/search/SearchPage'));
 const PasswordChangePage = lazy(() => import('@/pages/password-change/PasswordChangePage'));
 const DeleteAccountPage = lazy(() => import('@/pages/delete-account/DeleteAccountPage'));
+const AccordionTestPage = lazy(() => import('@/pages/test/AccordionTestPage'));
 
 const routes: RouteObject[] = [
     {
@@ -81,6 +82,14 @@ const routes: RouteObject[] = [
                 element: (
                     <Suspense fallback={<LoadingFallback />}>
                         <SearchPage />
+                    </Suspense>
+                ),
+            },
+            {
+                path: 'accordion-test',
+                element: (
+                    <Suspense fallback={<LoadingFallback />}>
+                        <AccordionTestPage />
                     </Suspense>
                 ),
             },

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -29,11 +29,11 @@ const Accordion: React.FC<AccordionProps> = ({ title, data, isExpanded = false, 
             <div className="flex w-full justify-center">
                 <button
                     onClick={onToggle}
-                    className="flex w-full items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
+                    className="flex w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
                 >
-                    <span className="text-sm">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
+                    <span className="text-14px-medium">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
                     <span className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
-                        <ChevronIcon width={14} />
+                        <ChevronIcon width={15} />
                     </span>
                 </button>
             </div>

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -1,0 +1,44 @@
+//통합 아코디언 컴포넌트
+import React from 'react';
+
+import ChevronIcon from '@/assets/chevronIcon.svg?react';
+import SnackIcon from '@/assets/snackIcon.svg?react';
+
+import type { AccordionProps } from '../../types/accordionTypes';
+import GlossaryContent from './GlossaryContent';
+
+const Accordion: React.FC<AccordionProps> = ({ title, data, isExpanded = false, onToggle }) => {
+    return (
+        <div className="max-w-md rounded-lg border border-blue-200 bg-white p-6">
+            {/* 헤더 */}
+            <div className="mb-4 flex flex-col items-start space-x-3">
+                <div className="mb-2 flex items-center space-x-2">
+                    <SnackIcon />
+                    <h3 className="text-lg font-bold text-black">{title}</h3>
+                </div>
+                <p className="mt-1 text-sm text-black">이 기사의 핵심 어휘들을 살펴보아요.</p>
+            </div>
+
+            {/* 구분선 */}
+            <div className="mb-4 border-t border-gray-300"></div>
+
+            {/* 컨텐츠(용어집) */}
+            {isExpanded && <GlossaryContent data={data} />}
+
+            {/* 토글 버튼 */}
+            <div className="flex w-full justify-center">
+                <button
+                    onClick={onToggle}
+                    className="flex w-full items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
+                >
+                    <span className="text-sm">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
+                    <span className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                        <ChevronIcon width={14} />
+                    </span>
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default Accordion;

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -1,5 +1,4 @@
 //통합 아코디언 컴포넌트
-
 import ChevronIcon from '@/assets/chevronIcon.svg?react';
 import SnackIcon from '@/assets/snackIcon.svg?react';
 

--- a/src/shared/components/Accordion/Accordion.tsx
+++ b/src/shared/components/Accordion/Accordion.tsx
@@ -1,41 +1,56 @@
 //통합 아코디언 컴포넌트
-import React from 'react';
 
 import ChevronIcon from '@/assets/chevronIcon.svg?react';
 import SnackIcon from '@/assets/snackIcon.svg?react';
 
-import type { AccordionProps } from '../../types/accordionTypes';
+import type { AccordionProps, GlossaryItem, QuizItem } from '../../types/accordionTypes';
 import GlossaryContent from './GlossaryContent';
+import QuizContent from './QuizContent';
 
-const Accordion: React.FC<AccordionProps> = ({ title, data, isExpanded = false, onToggle }) => {
+const Accordion = ({
+    title,
+    data,
+    isExpanded = false,
+    onToggle,
+}: AccordionProps | { title: string; data: QuizItem[]; isExpanded?: boolean; onToggle?: () => void }) => {
+    const isQuiz = data.length > 0 && 'question' in data[0];
     return (
-        <div className="max-w-md rounded-lg border border-blue-200 bg-white p-6">
+        <div className="border-main-30 max-w-md rounded-lg border-[3px] bg-white p-6">
             {/* 헤더 */}
             <div className="mb-4 flex flex-col items-start space-x-3">
                 <div className="mb-2 flex items-center space-x-2">
                     <SnackIcon />
-                    <h3 className="text-lg font-bold text-black">{title}</h3>
+                    <h3 className="text-24px-semibold">{title}</h3>
                 </div>
-                <p className="mt-1 text-sm text-black">이 기사의 핵심 어휘들을 살펴보아요.</p>
+                <p className="text-14px-medium text-black-50 mt-1">
+                    {isQuiz ? '기사를 다 읽으셨군요! 퀴즈를 풀러 가볼까요?' : '이 기사의 핵심 어휘들을 살펴보아요.'}
+                </p>
             </div>
 
             {/* 구분선 */}
             <div className="mb-4 border-t border-gray-300"></div>
 
-            {/* 컨텐츠(용어집) */}
-            {isExpanded && <GlossaryContent data={data} />}
+            {/* 컨텐츠(용어집/퀴즈) */}
+            {isExpanded &&
+                (isQuiz ? (
+                    <QuizContent data={data as QuizItem[]} onClose={onToggle} />
+                ) : (
+                    <GlossaryContent data={data as GlossaryItem[]} />
+                ))}
 
             {/* 토글 버튼 */}
             <div className="flex w-full justify-center">
-                <button
-                    onClick={onToggle}
-                    className="flex w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
-                >
-                    <span className="text-14px-medium">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
-                    <span className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
-                        <ChevronIcon width={15} />
-                    </span>
-                </button>
+                {(!isQuiz || !isExpanded) && (
+                    <button
+                        onClick={onToggle}
+                        className="flex w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-gray-100 px-8 py-2 text-gray-700 transition-colors hover:bg-gray-200"
+                    >
+                        <span className="text-14px-medium">{isExpanded ? '접어두기' : '펼쳐보기'}</span>
+                        <span className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                            <ChevronIcon width={20} />
+                        </span>
+                    </button>
+                )}
             </div>
         </div>
     );

--- a/src/shared/components/Accordion/GlossaryContent.tsx
+++ b/src/shared/components/Accordion/GlossaryContent.tsx
@@ -1,0 +1,24 @@
+//용어집 Content
+import React from 'react';
+
+import type { GlossaryItem } from '../../types/accordionTypes';
+
+interface GlossaryContentProps {
+    data: GlossaryItem[];
+}
+
+const GlossaryContent: React.FC<GlossaryContentProps> = ({ data }) => {
+    return (
+        <div className="mb-4 space-y-3">
+            {data.map((item, index) => (
+                <div key={item.word} className="space-y-1">
+                    <div className="text-main text-sm font-bold text-black">{item.word}</div>
+                    <div className="mb-2 text-sm text-black">{item.definition}</div>
+                    {index < data.length - 1 && <div className="border-t border-gray-300"></div>}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default GlossaryContent;

--- a/src/shared/components/Accordion/GlossaryContent.tsx
+++ b/src/shared/components/Accordion/GlossaryContent.tsx
@@ -9,12 +9,12 @@ interface GlossaryContentProps {
 
 const GlossaryContent: React.FC<GlossaryContentProps> = ({ data }) => {
     return (
-        <div className="mb-4 space-y-3">
+        <div className="mb-4 space-y-3 rounded-2xl border-1 border-gray-300 bg-white p-6">
             {data.map((item, index) => (
                 <div key={item.word} className="space-y-1">
                     <div className="text-main text-sm font-bold text-black">{item.word}</div>
                     <div className="mb-2 text-sm text-black">{item.definition}</div>
-                    {index < data.length - 1 && <div className="border-t border-gray-300"></div>}
+                    {index < data.length - 1 && <div className="border-b border-gray-300"></div>}
                 </div>
             ))}
         </div>

--- a/src/shared/components/Accordion/GlossaryContent.tsx
+++ b/src/shared/components/Accordion/GlossaryContent.tsx
@@ -1,13 +1,11 @@
 //용어집 Content
-import React from 'react';
-
 import type { GlossaryItem } from '../../types/accordionTypes';
 
 interface GlossaryContentProps {
     data: GlossaryItem[];
 }
 
-const GlossaryContent: React.FC<GlossaryContentProps> = ({ data }) => {
+const GlossaryContent = ({ data }: GlossaryContentProps) => {
     return (
         <div className="mb-4 space-y-3 rounded-2xl border-1 border-gray-300 bg-white p-6">
             {data.map((item, index) => (

--- a/src/shared/components/Accordion/QuizContent.tsx
+++ b/src/shared/components/Accordion/QuizContent.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+
+import type { QuizItem } from '../../types/accordionTypes';
+
+interface QuizContentProps {
+    data: QuizItem[];
+
+    onAnswersChange?: (_: number[]) => void;
+    // onAnswersChange?: (answers: number[]) => void;
+    // 원래 이거였는데 계속 ESLint 에러 떠서 주석처리함
+    onClose?: () => void;
+}
+
+const QuizContent = ({ data, onAnswersChange, onClose }: QuizContentProps) => {
+    const [current, setCurrent] = useState(0);
+    const [selected, setSelected] = useState<number | null>(null);
+    // answers 상태 제거
+    const [finished, setFinished] = useState(false);
+    const [userAnswers, setUserAnswers] = useState<number[]>([]);
+
+    const handleSelect = (idx: number) => {
+        setSelected(idx);
+    };
+
+    const handleNext = () => {
+        if (selected === null) return;
+        const newAnswers = [...userAnswers, selected];
+        setUserAnswers(newAnswers);
+        setSelected(null);
+        if (current < data.length - 1) {
+            setCurrent(current + 1);
+        } else {
+            setFinished(true);
+            console.log(
+                '사용자 답안:',
+                newAnswers.map((answer) => answer + 1)
+            );
+        }
+        onAnswersChange?.(newAnswers);
+    };
+
+    // 중단하기 버튼 클릭 시 답안 콘솔 출력
+    const handleClose = () => {
+        console.log(
+            '사용자 답안:',
+            userAnswers.map((answer) => answer + 1)
+        );
+        console.log('퀴즈 종료');
+        if (onClose) onClose();
+    };
+
+    if (finished) {
+        return <div className="py-8 text-center text-lg font-semibold">퀴즈 종료</div>;
+    }
+
+    const quiz = data[current];
+
+    return (
+        <div className="mx-auto w-full max-w-md">
+            {/* 문제 */}
+            <div className="text-18px-medium mb-6 text-black">
+                Q{current + 1}. {quiz.question}
+            </div>
+
+            {/* 선택지 */}
+            <div className="mb-8 flex flex-col gap-3">
+                {quiz.options.map((opt, idx) => (
+                    <button
+                        key={`${opt}-${idx}`}
+                        className={`text-14px-medium w-full rounded-lg border-1 px-4 py-2 transition-colors ${
+                            selected === idx
+                                ? 'bg-main border-main text-white'
+                                : 'border-main text-main hover:bg-main bg-white hover:text-white'
+                        } `}
+                        onClick={() => handleSelect(idx)}
+                    >
+                        <span className="mr-2">{idx + 1}.</span>
+                        {opt}
+                    </button>
+                ))}
+            </div>
+
+            {/* 하단 버튼 */}
+            <div className="flex flex-col items-center gap-2">
+                <button
+                    className={`text-14px-medium w-full rounded-lg px-4 py-2 text-base transition-colors ${selected !== null ? 'cursor-pointer bg-blue-200 text-blue-700' : 'cursor-not-allowed bg-blue-100 text-blue-300'} `}
+                    onClick={handleNext}
+                    disabled={selected === null}
+                >
+                    다음문제
+                </button>
+                <button className="w-full cursor-pointer rounded-lg px-4 text-gray-500" onClick={handleClose}>
+                    <span className="text-14px-medium border-b border-gray-500">중단하기</span>
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default QuizContent;

--- a/src/shared/components/Accordion/index.ts
+++ b/src/shared/components/Accordion/index.ts
@@ -1,0 +1,3 @@
+export { default as Accordion } from './Accordion';
+export { default as GlossaryContent } from './GlossaryContent';
+export { glossaryTestData } from './testData';

--- a/src/shared/components/Accordion/index.ts
+++ b/src/shared/components/Accordion/index.ts
@@ -1,0 +1,4 @@
+export { default as Accordion } from './Accordion';
+export { default as GlossaryContent } from './GlossaryContent';
+export { default as QuizContent } from './QuizContent';
+export { glossaryTestData, quizData } from './testData';

--- a/src/shared/components/Accordion/index.ts
+++ b/src/shared/components/Accordion/index.ts
@@ -1,3 +1,0 @@
-export { default as Accordion } from './Accordion';
-export { default as GlossaryContent } from './GlossaryContent';
-export { glossaryTestData } from './testData';

--- a/src/shared/components/Accordion/testData.ts
+++ b/src/shared/components/Accordion/testData.ts
@@ -1,0 +1,28 @@
+//테스트를 위해 임시로 만든 데이터입니다!
+import type { GlossaryItem } from '../../types/accordionTypes';
+
+// 용어집 테스트 데이터
+export const glossaryTestData: GlossaryItem[] = [
+    {
+        word: '안녕',
+        definition: '한국말로 인사 >_<',
+    },
+    {
+        word: '펭귄',
+        definition: '귀여워요',
+    },
+    {
+        word: '마라탕',
+        definition: '배고파요',
+    },
+    {
+        word: '과자',
+        definition: '맛있당',
+    },
+    {
+        word: '스낵',
+        definition: '화이팅🍀',
+    },
+];
+
+// API 연결 후에는 받아오는 데이터로 대체될 예정입니다.

--- a/src/shared/components/Accordion/testData.ts
+++ b/src/shared/components/Accordion/testData.ts
@@ -1,5 +1,5 @@
 //테스트를 위해 임시로 만든 데이터입니다!
-import type { GlossaryItem } from '../../types/accordionTypes';
+import type { GlossaryItem, QuizItem } from '../../types/accordionTypes';
 
 // 용어집 테스트 데이터
 export const glossaryTestData: GlossaryItem[] = [
@@ -25,4 +25,15 @@ export const glossaryTestData: GlossaryItem[] = [
     },
 ];
 
-// API 연결 후에는 받아오는 데이터로 대체될 예정입니다.
+export const quizData: QuizItem[] = [
+    {
+        question: '이번 프로젝트의 서비스 명은?',
+        options: ['스넉', '스낵', '스낵면', '스웩'],
+        answer: 0,
+    },
+    {
+        question: '지금은 무슨 계절인가요?',
+        options: ['봄', '여름', '가을', '겨울'],
+        answer: 0,
+    },
+];

--- a/src/shared/types/accordionTypes.ts
+++ b/src/shared/types/accordionTypes.ts
@@ -1,0 +1,11 @@
+export interface GlossaryItem {
+    word: string;
+    definition: string;
+}
+
+export interface AccordionProps {
+    title: string;
+    data: GlossaryItem[];
+    isExpanded?: boolean;
+    onToggle?: () => void;
+}

--- a/src/shared/types/accordionTypes.ts
+++ b/src/shared/types/accordionTypes.ts
@@ -9,3 +9,9 @@ export interface AccordionProps {
     isExpanded?: boolean;
     onToggle?: () => void;
 }
+
+export interface QuizItem {
+    question: string;
+    options: string[];
+    answer: number; // 정답 인덱스
+}


### PR DESCRIPTION
## 📌 Summary
- close #73 

## 📝 Tasks
- 아코디언 카드를 사용하는 용어집과 퀴즈가 비슷하면서도 디테일이 달라서 따로 branch 파서 작업하다가 한 개로 합쳤습니다! (#72은 아코디언 + 용어집만 되어있어요!)
- 퀴즈 같은 경우에는 용어집과 같이 testData.ts에 더미데이터를 넣어두었습니다.
- 선지를 눌러야만 다음 버튼이 활성화되며, 중단하기를 누르면 아코디언이 접힙니다!
- 나중에 활용성을 위해서 사용자가 선택한 선지가 콘솔에 찍히도록 했습니당
- eslint.config.mjs 파일에 unused 설정 off를 해도 계속 ESLint 에러가 나서 에러나는 파일 최상단에` /* eslint-disable no-unused-vars */` 추가 했습니당 ..


## ✅ PR Checklist (To Reviewer)

> accordion-test 페이지에서 확인 가능

- [ ] 콘솔에 선지가 잘 찍히는지
- [ ] 문제가 다음 문제로 잘 넘어가는지
- [ ] 전체적인 아코디언 + 용어집 + 퀴즈 확인해주시면 감사하겠습니다!


## 📸 Screenshot
<img width="1898" height="1220" alt="image" src="https://github.com/user-attachments/assets/60639d6d-7ec9-49e0-8c77-aad2eaef2dc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new Accordion component for displaying glossary and quiz content in an expandable format.
  * Added a dedicated test page featuring two independent accordions: one for a glossary and one for quizzes.
  * Users can interact with quizzes directly within the accordion, answering questions and viewing results.
  * Glossary entries are presented in an organized, expandable list for easy reference.

* **Chores**
  * Added sample test data for glossary and quizzes to demonstrate the new components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->