### PR TITLE
[Feat] 메모장 API 연동

### DIFF
--- a/src/pages/article/ArticlePage.tsx
+++ b/src/pages/article/ArticlePage.tsx
@@ -21,7 +21,7 @@ const ArticlePage = () => {
                     </div>
                     <div className="flex flex-1 items-center justify-end gap-1">
                         <div className="text-20px-medium text-black-70">메모장</div>
-                        <ToggleSwitch onChange={handleToggleChange} checked={false} />;
+                        <ToggleSwitch onChange={handleToggleChange} checked={false} />
                     </div>
                 </div>
                 <hr className="border-black-30 w-full border-t" />

--- a/src/pages/article/ArticlePage.tsx
+++ b/src/pages/article/ArticlePage.tsx
@@ -1,41 +1,64 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
 import SummarizedNewsContainer from '@/pages/article/components/SummarizedNewsContainer/SummarizedNewsContainer';
 import AccordionTestPage from '@/pages/test/AccordionTestPage';
 import ChainIcon from '@/shared/assets/icons/chain-icon.svg?react';
 import ToggleSwitch from '@/shared/components/button/ToggleSwitch';
 import CategoryChips from '@/shared/components/chip/CategoryChips';
+import MemoPad from '@/shared/components/modal/MemoPad/MemoPad';
 
 const ArticlePage = () => {
-    const handleToggleChange = (_checked: boolean) => {
-        handleToggle(_checked);
+    const { id } = useParams<{ id: string }>();
+    const articleId = id || '1'; // string 타입으로 통일, 기본값 "1"
+
+    // 메모장 상태 관리
+    const [isMemoPadOpen, setIsMemoPadOpen] = useState(false);
+
+    // 메모장 토글 핸들러
+    const handleToggleChange = (checked: boolean) => {
+        setIsMemoPadOpen(checked);
     };
 
     return (
-        <div className="w-[714px] pl-6">
-            <div className="mx-auto flex max-w-[714px] min-w-2xl flex-col gap-6 px-6 py-4">
-                <CategoryChips categories={['스포츠']} isClickable={false} bgColor="bg-main" />
-                <div className="flex items-center gap-4 overflow-x-auto whitespace-nowrap">
-                    <h1 className="text-36px-semibold flex-shrink-0">스포츠 기사</h1>
-                    <div className="flex items-center gap-1">
-                        <ChainIcon />
-                        <h2 className="text-20px-medium text-black-70">원문링크: https://abcd.co</h2>
+        <>
+            <div className="w-[714px] pl-6">
+                <div className="mx-auto flex max-w-[714px] min-w-2xl flex-col gap-6 px-6 py-4">
+                    <CategoryChips categories={['스포츠']} isClickable={false} bgColor="bg-main" />
+                    <div className="flex items-center gap-4 overflow-x-auto whitespace-nowrap">
+                        <h1 className="text-36px-semibold flex-shrink-0">스포츠 기사</h1>
+                        <div className="flex items-center gap-1">
+                            <ChainIcon />
+                            <h2 className="text-20px-medium text-black-70">원문링크: https://abcd.co</h2>
+                        </div>
+                        <div className="flex flex-1 items-center justify-end gap-1">
+                            <div className="text-20px-medium text-black-70">메모장</div>
+                            <ToggleSwitch onChange={handleToggleChange} checked={isMemoPadOpen} />
+                        </div>
                     </div>
-                    <div className="flex flex-1 items-center justify-end gap-1">
-                        <div className="text-20px-medium text-black-70">메모장</div>
-                        <ToggleSwitch onChange={handleToggleChange} checked={false} />
+                    <hr className="border-black-30 w-full border-t" />
+                    <div className="flex justify-center">
+                        <SummarizedNewsContainer />
                     </div>
+                    <AccordionTestPage />
                 </div>
-                <hr className="border-black-30 w-full border-t" />
-                <div className="flex justify-center">
-                    <SummarizedNewsContainer />
-                </div>
-                <AccordionTestPage />
             </div>
-        </div>
+
+            {/* 메모장 오버레이 */}
+            {isMemoPadOpen && (
+                <div className="fixed top-0 right-0 z-50 px-18 py-8">
+                    <div className="mt-20">
+                        <MemoPad articleId={articleId} />
+                    </div>
+                </div>
+            )}
+
+            {/* 디버깅용 정보 */}
+            <div className="fixed bottom-4 left-4 rounded bg-black p-2 text-xs text-white">
+                Debug: isMemoPadOpen={String(isMemoPadOpen)}, articleId={articleId}
+            </div>
+        </>
     );
 };
 
 export default ArticlePage;
-
-function handleToggle(_checked: boolean) {
-    throw new Error('Function not implemented.');
-}

--- a/src/pages/article/apis/memoApi.ts
+++ b/src/pages/article/apis/memoApi.ts
@@ -1,78 +1,27 @@
 import api from '@/shared/apis/api';
 
-import type {
-    CreateMemoRequest,
-    Memo,
-    MemoListParams,
-    MemoListResponse,
-    MemoResponse,
-    UpdateMemoRequest,
-} from '../types/memoTypes';
+import type { CreateMemoRequest, Memo, MemoResponse, UpdateMemoRequest } from '../types/memoTypes';
 
 /**
  * 메모 API 함수들
  */
 
-// 메모 목록 조회
-export const getMemos = async (params: MemoListParams = {}): Promise<MemoListResponse> => {
-    const { page = 0, size = 5 } = params;
-
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const response = await api.get<any>(`/api/memos?page=${page}&size=${size}`);
-
-        // API 응답 구조에 따라 result.memos 추출
-        if (response?.result?.memos) {
-            return {
-                memos: response.result.memos,
-                page: response.result.page || page,
-                size: response.result.size || size,
-                totalPages: response.result.totalPages || 0,
-                totalElements: response.result.totalElements || 0,
-            };
-        }
-
-        // 기존 구조 지원 (fallback)
-        if (response?.memos) {
-            return response;
-        }
-
-        // 응답 구조를 찾을 수 없는 경우 기본값 반환
-        return {
-            memos: [],
-            page,
-            size,
-            totalPages: 0,
-            totalElements: 0,
-        };
-    } catch (error) {
-        console.error('getMemos 에러:', error);
-        // 에러 발생 시에도 기본값 반환
-        return {
-            memos: [],
-            page,
-            size,
-            totalPages: 0,
-            totalElements: 0,
-        };
-    }
-};
-
 // 특정 기사의 메모 목록 조회 (필터링)
-export const getMemosByArticle = async (articleId: number, params: MemoListParams = {}): Promise<MemoListResponse> => {
-    const { page = 0, size = 5 } = params;
-    // API에서 articleId로 필터링하는 기능이 있다면 사용
-    // 현재는 전체 메모를 가져온 후 클라이언트에서 필터링
-    const allMemos = await getMemos({ page, size: 100 }); // 충분히 큰 size로 가져오기
+export const getMemosByArticle = async (articleId: number): Promise<Memo[]> => {
+    // 모든 메모를 가져온 후 특정 articleId로 필터링
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const allMemosResponse = await api.get<any>(`/api/memos?page=0&size=100`);
 
-    const filteredMemos = allMemos.memos.filter((memo) => memo.articleId === articleId);
+    let allMemos: Memo[] = [];
+    if (allMemosResponse?.result?.memos) {
+        allMemos = allMemosResponse.result.memos;
+    } else if (allMemosResponse?.memos) {
+        // 기존 구조 지원 (fallback)
+        allMemos = allMemosResponse.memos;
+    }
 
-    return {
-        ...allMemos,
-        memos: filteredMemos,
-        totalElements: filteredMemos.length,
-        totalPages: Math.ceil(filteredMemos.length / size),
-    };
+    // 특정 articleId에 해당하는 메모만 필터링하여 반환
+    return allMemos.filter((memo) => memo.articleId === articleId);
 };
 
 // 메모 생성
@@ -117,7 +66,7 @@ export const getMemo = async (articleId: number, memoId: number): Promise<Memo> 
     // API에 단일 메모 조회 엔드포인트가 있다면 사용
     // 현재는 목록에서 찾기
     const memos = await getMemosByArticle(articleId);
-    const memo = memos.memos.find((m) => m.memoId === memoId);
+    const memo = memos.find((m) => m.memoId === memoId);
     if (!memo) {
         throw new Error('메모를 찾을 수 없습니다.');
     }

--- a/src/pages/article/apis/memoApi.ts
+++ b/src/pages/article/apis/memoApi.ts
@@ -1,6 +1,13 @@
 import api from '@/shared/apis/api';
 
-import type { CreateMemoRequest, Memo, MemoResponse, UpdateMemoRequest } from '../types/memoTypes';
+import type {
+    ApiResponse,
+    CreateMemoRequest,
+    Memo,
+    MemoResponse,
+    MemosResult,
+    UpdateMemoRequest,
+} from '../types/memoTypes';
 
 /**
  * 메모 API 함수들
@@ -9,15 +16,11 @@ import type { CreateMemoRequest, Memo, MemoResponse, UpdateMemoRequest } from '.
 // 특정 기사의 메모 목록 조회 (필터링)
 export const getMemosByArticle = async (articleId: number): Promise<Memo[]> => {
     // 모든 메모를 가져온 후 특정 articleId로 필터링
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const allMemosResponse = await api.get<any>(`/api/memos?page=0&size=100`);
+    const allMemosResponse = await api.get<ApiResponse<MemosResult>>(`/api/memos?page=0&size=100`);
 
     let allMemos: Memo[] = [];
     if (allMemosResponse?.result?.memos) {
         allMemos = allMemosResponse.result.memos;
-    } else if (allMemosResponse?.memos) {
-        // 기존 구조 지원 (fallback)
-        allMemos = allMemosResponse.memos;
     }
 
     // 특정 articleId에 해당하는 메모만 필터링하여 반환
@@ -28,32 +31,31 @@ export const getMemosByArticle = async (articleId: number): Promise<Memo[]> => {
 export const createMemo = async (articleId: number, data: CreateMemoRequest): Promise<MemoResponse> => {
     // CreateMemoRequest 타입 사용 확인
     const requestData: CreateMemoRequest = data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response = await api.post<any>(`/api/articles/${articleId}/memos`, requestData);
+    const response = await api.post<ApiResponse<MemoResponse>>(`/api/articles/${articleId}/memos`, requestData);
 
     // API 응답 구조에 따라 result에서 데이터 추출
     if (response?.result) {
         return response.result;
     }
 
-    // 기존 구조 지원 (fallback)
-    return response;
+    throw new Error('메모 생성 응답에서 필요한 데이터를 찾을 수 없습니다.');
 };
 
 // 메모 수정
 export const updateMemo = async (articleId: number, memoId: number, data: UpdateMemoRequest): Promise<MemoResponse> => {
     // UpdateMemoRequest 타입 사용 확인
     const requestData: UpdateMemoRequest = data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const response = await api.patch<any>(`/api/articles/${articleId}/memos/${memoId}`, requestData);
+    const response = await api.patch<ApiResponse<MemoResponse>>(
+        `/api/articles/${articleId}/memos/${memoId}`,
+        requestData
+    );
 
     // API 응답 구조에 따라 result에서 데이터 추출
     if (response?.result) {
         return response.result;
     }
 
-    // 기존 구조 지원 (fallback)
-    return response;
+    throw new Error('메모 수정 응답에서 필요한 데이터를 찾을 수 없습니다.');
 };
 
 // 메모 삭제

--- a/src/pages/article/apis/memoApi.ts
+++ b/src/pages/article/apis/memoApi.ts
@@ -1,0 +1,125 @@
+import api from '@/shared/apis/api';
+
+import type {
+    CreateMemoRequest,
+    Memo,
+    MemoListParams,
+    MemoListResponse,
+    MemoResponse,
+    UpdateMemoRequest,
+} from '../types/memoTypes';
+
+/**
+ * 메모 API 함수들
+ */
+
+// 메모 목록 조회
+export const getMemos = async (params: MemoListParams = {}): Promise<MemoListResponse> => {
+    const { page = 0, size = 5 } = params;
+
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const response = await api.get<any>(`/api/memos?page=${page}&size=${size}`);
+
+        // API 응답 구조에 따라 result.memos 추출
+        if (response?.result?.memos) {
+            return {
+                memos: response.result.memos,
+                page: response.result.page || page,
+                size: response.result.size || size,
+                totalPages: response.result.totalPages || 0,
+                totalElements: response.result.totalElements || 0,
+            };
+        }
+
+        // 기존 구조 지원 (fallback)
+        if (response?.memos) {
+            return response;
+        }
+
+        // 응답 구조를 찾을 수 없는 경우 기본값 반환
+        return {
+            memos: [],
+            page,
+            size,
+            totalPages: 0,
+            totalElements: 0,
+        };
+    } catch (error) {
+        console.error('getMemos 에러:', error);
+        // 에러 발생 시에도 기본값 반환
+        return {
+            memos: [],
+            page,
+            size,
+            totalPages: 0,
+            totalElements: 0,
+        };
+    }
+};
+
+// 특정 기사의 메모 목록 조회 (필터링)
+export const getMemosByArticle = async (articleId: number, params: MemoListParams = {}): Promise<MemoListResponse> => {
+    const { page = 0, size = 5 } = params;
+    // API에서 articleId로 필터링하는 기능이 있다면 사용
+    // 현재는 전체 메모를 가져온 후 클라이언트에서 필터링
+    const allMemos = await getMemos({ page, size: 100 }); // 충분히 큰 size로 가져오기
+
+    const filteredMemos = allMemos.memos.filter((memo) => memo.articleId === articleId);
+
+    return {
+        ...allMemos,
+        memos: filteredMemos,
+        totalElements: filteredMemos.length,
+        totalPages: Math.ceil(filteredMemos.length / size),
+    };
+};
+
+// 메모 생성
+export const createMemo = async (articleId: number, data: CreateMemoRequest): Promise<MemoResponse> => {
+    // CreateMemoRequest 타입 사용 확인
+    const requestData: CreateMemoRequest = data;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await api.post<any>(`/api/articles/${articleId}/memos`, requestData);
+
+    // API 응답 구조에 따라 result에서 데이터 추출
+    if (response?.result) {
+        return response.result;
+    }
+
+    // 기존 구조 지원 (fallback)
+    return response;
+};
+
+// 메모 수정
+export const updateMemo = async (articleId: number, memoId: number, data: UpdateMemoRequest): Promise<MemoResponse> => {
+    // UpdateMemoRequest 타입 사용 확인
+    const requestData: UpdateMemoRequest = data;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const response = await api.patch<any>(`/api/articles/${articleId}/memos/${memoId}`, requestData);
+
+    // API 응답 구조에 따라 result에서 데이터 추출
+    if (response?.result) {
+        return response.result;
+    }
+
+    // 기존 구조 지원 (fallback)
+    return response;
+};
+
+// 메모 삭제
+export const deleteMemo = async (articleId: number, memoId: number): Promise<void> => {
+    return api.delete(`/api/articles/${articleId}/memos/${memoId}`);
+};
+
+// 메모 단일 조회 (필요시 사용)
+export const getMemo = async (articleId: number, memoId: number): Promise<Memo> => {
+    // API에 단일 메모 조회 엔드포인트가 있다면 사용
+    // 현재는 목록에서 찾기
+    const memos = await getMemosByArticle(articleId);
+    const memo = memos.memos.find((m) => m.memoId === memoId);
+    if (!memo) {
+        throw new Error('메모를 찾을 수 없습니다.');
+    }
+    return memo;
+};

--- a/src/pages/article/hooks/index.ts
+++ b/src/pages/article/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useMemoManagement } from './useMemoManagement';

--- a/src/pages/article/hooks/useMemoManagement.ts
+++ b/src/pages/article/hooks/useMemoManagement.ts
@@ -34,10 +34,10 @@ export const useMemoManagement = ({ articleId }: UseMemoManagementProps) => {
         setMemoState((prev) => ({ ...prev, isLoading: true, error: null }));
 
         try {
-            const response = await getMemosByArticle(typeof articleId === 'string' ? Number(articleId) : articleId);
+            const memos = await getMemosByArticle(typeof articleId === 'string' ? Number(articleId) : articleId);
             setMemoState((prev) => ({
                 ...prev,
-                memos: response.memos,
+                memos: memos,
                 isLoading: false,
             }));
         } catch (error) {

--- a/src/pages/article/hooks/useMemoManagement.ts
+++ b/src/pages/article/hooks/useMemoManagement.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { createMemo, deleteMemo, getMemosByArticle, updateMemo } from '../apis/memoApi';
+import type { Memo } from '../types/memoTypes';
+
+interface UseMemoManagementProps {
+    articleId: string | number;
+}
+
+interface MemoState {
+    memos: Memo[];
+    isLoading: boolean;
+    error: string | null;
+    isCreating: boolean;
+    isUpdating: boolean;
+    isDeleting: boolean;
+}
+
+export const useMemoManagement = ({ articleId }: UseMemoManagementProps) => {
+    // 메모 상태
+    const [memoState, setMemoState] = useState<MemoState>({
+        memos: [],
+        isLoading: false,
+        error: null,
+        isCreating: false,
+        isUpdating: false,
+        isDeleting: false,
+    });
+
+    // 메모 목록 조회
+    const fetchMemos = useCallback(async () => {
+        if (!articleId) return;
+
+        setMemoState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+        try {
+            const response = await getMemosByArticle(typeof articleId === 'string' ? Number(articleId) : articleId);
+            setMemoState((prev) => ({
+                ...prev,
+                memos: response.memos,
+                isLoading: false,
+            }));
+        } catch (error) {
+            setMemoState((prev) => ({
+                ...prev,
+                error: error instanceof Error ? error.message : '메모를 불러오는데 실패했습니다.',
+                isLoading: false,
+            }));
+        }
+    }, [articleId]);
+
+    // 메모 생성
+    const createNewMemo = useCallback(
+        async (content: string) => {
+            if (!articleId || !content.trim()) return;
+
+            setMemoState((prev) => ({ ...prev, isCreating: true, error: null }));
+
+            try {
+                const articleIdNum = typeof articleId === 'string' ? Number(articleId) : articleId;
+                const response = await createMemo(articleIdNum, { content: content }); // trim() 제거
+
+                // API 응답 구조에 따라 memoId와 content 추출
+                const memoId = response?.memoId;
+                const memoContent = response?.content;
+
+                if (!memoId || !memoContent) {
+                    throw new Error('메모 생성 응답에서 필요한 데이터를 찾을 수 없습니다.');
+                }
+
+                // 새로 생성된 메모를 목록에 추가 (원본 content 사용)
+                const createdMemo: Memo = {
+                    memoId,
+                    content: content, // 원본 content 사용 (trim하지 않음)
+                    createdAt: new Date().toISOString(),
+                    articleId: articleIdNum,
+                };
+
+                setMemoState((prev) => ({
+                    ...prev,
+                    memos: [createdMemo, ...prev.memos],
+                    isCreating: false,
+                }));
+
+                return createdMemo;
+            } catch (error) {
+                setMemoState((prev) => ({
+                    ...prev,
+                    error: error instanceof Error ? error.message : '메모 생성에 실패했습니다.',
+                    isCreating: false,
+                }));
+                throw error;
+            }
+        },
+        [articleId]
+    );
+
+    // 메모 수정
+    const updateExistingMemo = useCallback(
+        async (memoId: number, content: string) => {
+            if (!articleId || !content.trim()) return;
+
+            setMemoState((prev) => ({ ...prev, isUpdating: true, error: null }));
+
+            try {
+                const articleIdNum = typeof articleId === 'string' ? Number(articleId) : articleId;
+                const response = await updateMemo(articleIdNum, memoId, { content: content }); // trim() 제거
+
+                // API 응답 구조에 따라 content 추출
+                const updatedContent = response?.content;
+
+                if (!updatedContent) {
+                    throw new Error('메모 수정 응답에서 필요한 데이터를 찾을 수 없습니다.');
+                }
+
+                // 메모 목록에서 해당 메모 업데이트 (원본 content 사용)
+                setMemoState((prev) => ({
+                    ...prev,
+                    memos: prev.memos.map((memo) =>
+                        memo.memoId === memoId
+                            ? { ...memo, content: content } // 원본 content 사용 (trim하지 않음)
+                            : memo
+                    ),
+                    isUpdating: false,
+                }));
+
+                return response;
+            } catch (error) {
+                setMemoState((prev) => ({
+                    ...prev,
+                    error: error instanceof Error ? error.message : '메모 수정에 실패했습니다.',
+                    isUpdating: false,
+                }));
+                throw error;
+            }
+        },
+        [articleId]
+    );
+
+    // 메모 삭제
+    const removeMemo = useCallback(
+        async (memoId: number) => {
+            if (!articleId) return;
+
+            setMemoState((prev) => ({ ...prev, isDeleting: true, error: null }));
+
+            try {
+                const articleIdNum = typeof articleId === 'string' ? Number(articleId) : articleId;
+                await deleteMemo(articleIdNum, memoId);
+
+                // 메모 목록에서 해당 메모 제거
+                setMemoState((prev) => ({
+                    ...prev,
+                    memos: prev.memos.filter((memo) => memo.memoId !== memoId),
+                    isDeleting: false,
+                }));
+            } catch (error) {
+                setMemoState((prev) => ({
+                    ...prev,
+                    error: error instanceof Error ? error.message : '메모 삭제에 실패했습니다.',
+                    isDeleting: false,
+                }));
+                throw error;
+            }
+        },
+        [articleId]
+    );
+
+    // 에러 초기화
+    const clearError = useCallback(() => {
+        setMemoState((prev) => ({ ...prev, error: null }));
+    }, []);
+
+    // 컴포넌트 마운트 시 메모 목록 조회
+    useEffect(() => {
+        void fetchMemos();
+    }, [fetchMemos]);
+
+    return {
+        // 상태
+        memos: memoState.memos,
+        isLoading: memoState.isLoading,
+        error: memoState.error,
+        isCreating: memoState.isCreating,
+        isUpdating: memoState.isUpdating,
+        isDeleting: memoState.isDeleting,
+
+        // 액션
+        fetchMemos,
+        createNewMemo,
+        updateExistingMemo,
+        removeMemo,
+        clearError,
+    };
+};

--- a/src/pages/article/types/memoTypes.ts
+++ b/src/pages/article/types/memoTypes.ts
@@ -1,0 +1,38 @@
+// 메모 기본 타입
+export interface Memo {
+    memoId: number;
+    content: string;
+    createdAt: string;
+    articleId: number;
+}
+
+// 메모 생성 요청 타입
+export interface CreateMemoRequest {
+    content: string;
+}
+
+// 메모 수정 요청 타입
+export interface UpdateMemoRequest {
+    content: string;
+}
+
+// 메모 목록 조회 응답 타입
+export interface MemoListResponse {
+    memos: Memo[];
+    page: number;
+    size: number;
+    totalPages: number;
+    totalElements: number;
+}
+
+// 메모 목록 조회 파라미터 타입
+export interface MemoListParams {
+    page?: number;
+    size?: number;
+}
+
+// 메모 생성/수정 응답 타입
+export interface MemoResponse {
+    memoId: number;
+    content: string;
+}

--- a/src/pages/article/types/memoTypes.ts
+++ b/src/pages/article/types/memoTypes.ts
@@ -1,3 +1,21 @@
+// API 응답 공통 구조
+export interface ApiResponse<T> {
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: T;
+    error: unknown;
+}
+
+// 메모 목록 조회 결과 타입
+export interface MemosResult {
+    memos: Memo[];
+    page: number;
+    size: number;
+    totalPages: number;
+    totalElements: number;
+}
+
 // 메모 기본 타입
 export interface Memo {
     memoId: number;
@@ -14,21 +32,6 @@ export interface CreateMemoRequest {
 // 메모 수정 요청 타입
 export interface UpdateMemoRequest {
     content: string;
-}
-
-// 메모 목록 조회 응답 타입
-export interface MemoListResponse {
-    memos: Memo[];
-    page: number;
-    size: number;
-    totalPages: number;
-    totalElements: number;
-}
-
-// 메모 목록 조회 파라미터 타입
-export interface MemoListParams {
-    page?: number;
-    size?: number;
 }
 
 // 메모 생성/수정 응답 타입

--- a/src/pages/my/DummyData/DummyMemos.ts
+++ b/src/pages/my/DummyData/DummyMemos.ts
@@ -1,7 +1,10 @@
 const dummyMemos = Array.from({ length: 40 }, (_, i) => ({
-    id: i + 1,
-    date: `2025.07.${i + 1 < 10 ? '0' + (i + 1) : i + 1}`,
+    memoId: i + 1,
+    id: i + 1, // 기존 호환성
     content: `메모 내용 ${i + 1}`,
+    createdAt: `2025-07-${i + 1 < 10 ? '0' + (i + 1) : i + 1}T00:00:00.000Z`,
+    date: `2025.07.${i + 1 < 10 ? '0' + (i + 1) : i + 1}`, // 기존 호환성
+    articleId: Math.floor(Math.random() * 10) + 1, // 랜덤 기사 ID
 }));
 
 export default dummyMemos;

--- a/src/pages/my/types/types.ts
+++ b/src/pages/my/types/types.ts
@@ -1,7 +1,11 @@
 export type Memo = {
+    memoId: number;
+    content: string;
+    createdAt: string;
+    articleId: number;
+    // 기존 호환성을 위한 별칭
     id: number;
     date: string;
-    content: string;
 };
 
 export type Scrap = {

--- a/src/pages/test/QuizCommentaryPage.tsx
+++ b/src/pages/test/QuizCommentaryPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import ArticleCard from '@/shared/components/card/ArticleCard';
 import FieldChips from '@/shared/components/chip/FieldChips';
+import MemoPad from '@/shared/components/modal/MemoPad/MemoPad';
 import ArticleHeader from '@/shared/components/quiz/ArticleHeader';
 import QuizCommentary from '@/shared/components/quiz/QuizCommentary';
 import { quizCommentaryDummyData } from '@/shared/components/quiz/quizCommentaryData';
@@ -10,6 +11,14 @@ import QuizTestButtons from '@/shared/components/quiz/QuizTestButtons';
 const QuizCommentaryPage = () => {
     // ===== 테스트 모드 (현재 활성화) =====
     const [testMode, setTestMode] = useState<'allCorrect' | 'partialCorrect' | 'allWrong'>('partialCorrect');
+
+    // ===== 메모장 상태 관리 =====
+    const [isMemoPadOpen, setIsMemoPadOpen] = useState(false);
+
+    // 메모장 토글 핸들러
+    const handleMemoPadToggle = (enabled: boolean) => {
+        setIsMemoPadOpen(enabled);
+    };
 
     // 테스트용 데이터 생성
     const getTestData = () => {
@@ -66,8 +75,8 @@ const QuizCommentaryPage = () => {
                         <ArticleHeader
                             title="기사 제목"
                             originalLink="https://www.snack.com"
-                            isNotepadEnabled={true}
-                            onNotepadToggle={() => {}}
+                            isNotepadEnabled={isMemoPadOpen}
+                            onNotepadToggle={handleMemoPadToggle}
                         />
 
                         {/* 현재 테스트 데이터 사용 */}
@@ -89,6 +98,15 @@ const QuizCommentaryPage = () => {
                     </div>
                 </div>
             </div>
+
+            {/* 메모장 오버레이 */}
+            {isMemoPadOpen && (
+                <div className="fixed top-0 right-0 z-50 px-18 py-8">
+                    <div className="mt-20">
+                        <MemoPad />
+                    </div>
+                </div>
+            )}
         </>
     );
 };

--- a/src/pages/test/QuizCommentaryPage.tsx
+++ b/src/pages/test/QuizCommentaryPage.tsx
@@ -103,7 +103,7 @@ const QuizCommentaryPage = () => {
             {isMemoPadOpen && (
                 <div className="fixed top-0 right-0 z-50 px-18 py-8">
                     <div className="mt-20">
-                        <MemoPad />
+                        <MemoPad articleId="test-article-123" />
                     </div>
                 </div>
             )}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -34,18 +34,18 @@ const routes: RouteObject[] = [
             },
 
             {
-                path: 'article',
-                element: (
-                    <Suspense fallback={<LoadingFallback />}>
-                        <ArticlePage />
-                    </Suspense>
-                ),
-            },
-            {
                 path: 'article/quiz-commentary',
                 element: (
                     <Suspense fallback={<LoadingFallback />}>
                         <QuizCommentary />
+                    </Suspense>
+                ),
+            },
+            {
+                path: 'article/:id?',
+                element: (
+                    <Suspense fallback={<LoadingFallback />}>
+                        <ArticlePage />
                     </Suspense>
                 ),
             },

--- a/src/shared/apis/api.ts
+++ b/src/shared/apis/api.ts
@@ -22,7 +22,7 @@ const api = {
             headers: options?.headers,
             timeout: options?.timeout,
         });
-        return response.data.data;
+        return response.data as T;
     },
 
     /**
@@ -33,7 +33,7 @@ const api = {
             headers: options?.headers,
             timeout: options?.timeout,
         });
-        return response.data.data;
+        return response.data as T;
     },
 
     /**
@@ -44,7 +44,7 @@ const api = {
             headers: options?.headers,
             timeout: options?.timeout,
         });
-        return response.data.data;
+        return response.data as T;
     },
 
     /**
@@ -55,7 +55,7 @@ const api = {
             headers: options?.headers,
             timeout: options?.timeout,
         });
-        return response.data.data;
+        return response.data as T;
     },
 
     /**
@@ -66,7 +66,7 @@ const api = {
             headers: options?.headers,
             timeout: options?.timeout,
         });
-        return response.data.data;
+        return response.data as T;
     },
 };
 

--- a/src/shared/components/modal/MemoPad/MemoPad.tsx
+++ b/src/shared/components/modal/MemoPad/MemoPad.tsx
@@ -140,11 +140,6 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
                     {isDeleting && <div className="text-orange-600">삭제 중...</div>}
                 </div>
             </div>
-
-            {/* 디버그 정보 */}
-            <div className="mt-2 text-center text-xs text-gray-500">
-                Article ID: {articleId} | Memos: {memos.length} | Current Memo ID: {currentEditingMemoId}
-            </div>
         </div>
     );
 };

--- a/src/shared/components/modal/MemoPad/MemoPad.tsx
+++ b/src/shared/components/modal/MemoPad/MemoPad.tsx
@@ -1,8 +1,121 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useMemoManagement } from '@/pages/article/hooks';
+
 interface MemoPadProps {
     articleId: string;
 }
 
 const MemoPad = ({ articleId }: MemoPadProps) => {
+    // 메모 관리 훅 사용
+    const {
+        memos,
+        isLoading,
+        error,
+        isCreating,
+        isUpdating,
+        isDeleting,
+        createNewMemo,
+        updateExistingMemo,
+        removeMemo,
+        clearError,
+    } = useMemoManagement({ articleId });
+
+    // 자동 저장을 위한 타이머 ref
+    const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // 현재 편집 중인 메모 ID (새 메모는 0)
+    const [currentEditingMemoId, setCurrentEditingMemoId] = useState<number>(0);
+
+    // 현재 textarea 내용
+    const [currentContent, setCurrentContent] = useState('');
+
+    // 자동 저장 타이머 설정
+    const startAutoSaveTimer = (memoId: number, content: string): void => {
+        // 빈 내용이고 새 메모인 경우 타이머 시작하지 않음
+        if (content.trim().length === 0 && memoId === 0) {
+            return;
+        }
+
+        if (autoSaveTimerRef.current) {
+            clearTimeout(autoSaveTimerRef.current);
+        }
+
+        autoSaveTimerRef.current = setTimeout(() => {
+            const autoSave = async () => {
+                try {
+                    if (content.trim().length === 0) {
+                        // 내용이 비어있으면 삭제 (기존 메모만)
+                        if (memoId > 0) {
+                            await removeMemo(memoId);
+                            // 삭제 후 새 메모 모드로 전환
+                            setCurrentEditingMemoId(0);
+                            setCurrentContent('');
+                        }
+                    } else if (memoId === 0) {
+                        // 새 메모 생성 (내용이 있을 때만)
+                        const newMemo = await createNewMemo(content);
+                        if (newMemo) {
+                            // 생성된 메모의 ID로 설정하여 수정 모드로 전환
+                            setCurrentEditingMemoId(newMemo.memoId);
+                        }
+                    } else {
+                        // 기존 메모 수정
+                        await updateExistingMemo(memoId, content);
+                    }
+                } catch (error) {
+                    console.error('자동 저장 실패:', error);
+                }
+            };
+            void autoSave();
+        }, 3000); // 3초 딜레이
+    };
+
+    // textarea 내용 변경 핸들러
+    const handleContentChange = (content: string) => {
+        setCurrentContent(content);
+
+        // 빈 내용이거나 사용자가 실제로 입력한 경우에만 자동 저장 타이머 시작
+        if (content.trim().length > 0 || currentEditingMemoId > 0) {
+            startAutoSaveTimer(currentEditingMemoId, content);
+        }
+    };
+
+    // 컴포넌트 마운트 시 기존 메모가 있으면 첫 번째 메모 내용으로 설정
+    useEffect(() => {
+        // 이미 편집 중인 메모가 있으면 덮어쓰지 않음
+        if (currentEditingMemoId > 0) return;
+
+        if (memos.length > 0 && !isLoading) {
+            const firstMemo = memos[0];
+            setCurrentContent(firstMemo.content);
+            setCurrentEditingMemoId(firstMemo.memoId);
+        } else if (memos.length === 0 && !isLoading) {
+            // 메모가 없으면 새 메모 모드로 설정
+            setCurrentContent('');
+            setCurrentEditingMemoId(0);
+        }
+    }, [memos, isLoading, currentEditingMemoId]);
+
+    // 컴포넌트 언마운트 시 타이머 정리
+    useEffect(() => {
+        return () => {
+            if (autoSaveTimerRef.current) {
+                clearTimeout(autoSaveTimerRef.current);
+            }
+        };
+    }, []);
+
+    // 에러 메시지 자동 숨김
+    useEffect(() => {
+        if (error) {
+            const timer = setTimeout(() => {
+                clearError();
+            }, 5000);
+            return () => clearTimeout(timer);
+        }
+    }, [error, clearError]);
+
     return (
         <div className="border-main flex h-[440px] w-[360px] flex-col items-center justify-center rounded-[48px] border-[2px] bg-white shadow-2xl">
             <div className="text-36px-medium mb-4 justify-center">메모장</div>
@@ -12,12 +125,26 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
             <div className="border-black-30 h-[280px] w-[300px] rounded-[16px] border-[2px] px-2 py-3">
                 <textarea
                     placeholder="메모를 입력하세요..."
-                    className="text-18px-medium placeholder-black-70 h-full w-full resize-none overflow-y-scroll bg-[linear-gradient(to_bottom,transparent_31px,#94a3b8_31.5px,transparent_32px)] bg-[length:calc(100%-10px)_32px] [background-attachment:local] bg-repeat-y pr-[12px] text-[16px] leading-[32px] outline-none"
+                    value={currentContent}
+                    onChange={(e) => handleContentChange(e.target.value)}
+                    disabled={isLoading}
+                    className="text-18px-medium placeholder-black-70 h-full w-full resize-none overflow-y-scroll bg-[linear-gradient(to_bottom,transparent_31px,#94a3b8_31.5px,transparent_32px)] bg-[length:calc(100%-10px)_32px] [background-attachment:local] bg-repeat-y pr-[12px] text-[16px] leading-[32px] outline-none disabled:opacity-50"
                 />
+
+                {/* 상태 메시지 영역 */}
+                <div className="mt-2 text-center text-xs">
+                    {isLoading && <div className="text-blue-600">메모를 불러오고 있습니다...</div>}
+                    {error && <div className="text-red-600">저장되지 않았습니다.</div>}
+                    {isCreating && <div className="text-green-600">저장 중...</div>}
+                    {isUpdating && <div className="text-green-600">수정 중...</div>}
+                    {isDeleting && <div className="text-orange-600">삭제 중...</div>}
+                </div>
             </div>
 
             {/* 디버그 정보 */}
-            <div className="mt-2 text-center text-xs text-gray-500">Article ID: {articleId}</div>
+            <div className="mt-2 text-center text-xs text-gray-500">
+                Article ID: {articleId} | Memos: {memos.length} | Current Memo ID: {currentEditingMemoId}
+            </div>
         </div>
     );
 };

--- a/src/shared/components/modal/MemoPad/MemoPad.tsx
+++ b/src/shared/components/modal/MemoPad/MemoPad.tsx
@@ -1,14 +1,23 @@
-const MemoPad = () => {
+interface MemoPadProps {
+    articleId: string;
+}
+
+const MemoPad = ({ articleId }: MemoPadProps) => {
     return (
         <div className="border-main flex h-[440px] w-[360px] flex-col items-center justify-center rounded-[48px] border-[2px] bg-white shadow-2xl">
             <div className="text-36px-medium mb-4 justify-center">메모장</div>
             <div className="bg-main mb-6 h-[2px] w-[300px]"></div>
+
+            {/* 메모 입력 영역 */}
             <div className="border-black-30 h-[280px] w-[300px] rounded-[16px] border-[2px] px-2 py-3">
                 <textarea
                     placeholder="메모를 입력하세요..."
                     className="text-18px-medium placeholder-black-70 h-full w-full resize-none overflow-y-scroll bg-[linear-gradient(to_bottom,transparent_31px,#94a3b8_31.5px,transparent_32px)] bg-[length:calc(100%-10px)_32px] [background-attachment:local] bg-repeat-y pr-[12px] text-[16px] leading-[32px] outline-none"
                 />
             </div>
+
+            {/* 디버그 정보 */}
+            <div className="mt-2 text-center text-xs text-gray-500">Article ID: {articleId}</div>
         </div>
     );
 };

--- a/src/shared/components/modal/MemoPad/MemoPad.tsx
+++ b/src/shared/components/modal/MemoPad/MemoPad.tsx
@@ -1,6 +1,6 @@
 const MemoPad = () => {
     return (
-        <div className="border-main flex h-[440px] w-[360px] flex-col items-center justify-center rounded-[48px] border-[2px] shadow-2xl">
+        <div className="border-main flex h-[440px] w-[360px] flex-col items-center justify-center rounded-[48px] border-[2px] bg-white shadow-2xl">
             <div className="text-36px-medium mb-4 justify-center">메모장</div>
             <div className="bg-main mb-6 h-[2px] w-[300px]"></div>
             <div className="border-black-30 h-[280px] w-[300px] rounded-[16px] border-[2px] px-2 py-3">

--- a/src/shared/components/quiz/ArticleHeader.tsx
+++ b/src/shared/components/quiz/ArticleHeader.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import LinkIcon from '@/shared/assets/icons/link.svg?react';
 
 import ToggleSwitch from '../button/ToggleSwitch';
@@ -17,12 +15,10 @@ function ArticleHeader({
     isNotepadEnabled = false,
     onNotepadToggle,
 }: ArticleHeaderProps) {
-    const [internalNotepadState, setInternalNotepadState] = useState(isNotepadEnabled);
-
     const handleNotepadToggle = (checked: boolean) => {
-        setInternalNotepadState(checked);
         onNotepadToggle?.(checked);
     };
+
     return (
         <div className="mb-8 w-full border-b border-gray-200 pb-4">
             <div className="flex items-center justify-between">
@@ -43,7 +39,7 @@ function ArticleHeader({
                 {/* 메모장 토글 */}
                 <div className="flex items-center gap-2">
                     <span className="text-20px-medium text-gray-500">메모장</span>
-                    <ToggleSwitch checked={internalNotepadState} onChange={handleNotepadToggle} />
+                    <ToggleSwitch checked={isNotepadEnabled} onChange={handleNotepadToggle} />
                 </div>
             </div>
         </div>

--- a/src/shared/utils/interceptors/requestInterceptor.ts
+++ b/src/shared/utils/interceptors/requestInterceptor.ts
@@ -4,9 +4,7 @@ import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
  * 토큰을 가져오는 함수 (나중에 구현)
  */
 const getAccessToken = (): string | null => {
-    // TODO: 실제 토큰 관리 로직 구현
-    // localStorage, sessionStorage, 또는 상태 관리에서 토큰 가져오기
-    return null;
+    return localStorage.getItem('accessToken');
 };
 
 /**
@@ -21,11 +19,7 @@ export const handleRequestSuccess = (config: InternalAxiosRequestConfig): Intern
 
     // 개발 환경에서 요청 로깅
     if (import.meta.env.DEV) {
-        console.log(`[API Request] ${config.method?.toUpperCase()} ${config.url}`, {
-            data: config.data,
-            params: config.params,
-            headers: config.headers,
-        });
+        console.log(`[API Request] ${config.method?.toUpperCase()} ${config.url}`);
     }
 
     return config;


### PR DESCRIPTION
## 📌 Summary
- close #110 

## 📝 Tasks
- ArticlePage의 메모장 토글 클릭 시 메모장 보임
- 메모패드의 상태 콘솔로 표현
- 메모 최종 작성 이후 3초가 지나면 자동 저장(수정도 마찬가지)
- 메모패드가 비어있게 된 후 3초가 지나면 메모 삭제
- 메모패드 하단에 메모패드의 상태 표현


## ✅ PR Checklist (To Reviewer)
- [ ] 특정 기사의 메모가 잘 조회되는지?
- [ ] 메모패드 속 내용이 잘 저장되는지?
- [ ] 메모패드 속 내용이 잘 수정되는지?
- [ ] 메모패드 속 내용이 잘 삭제되는지?
- [ ] 메모패드를 껐다 켜도 기존의 메모가 잘 조회되는지?

## 📸 Screenshot
<img width="2880" height="1170" alt="image" src="https://github.com/user-attachments/assets/3b624217-1326-4cde-85ee-49ae93fa9476" />