### PR TITLE
[Feat] 검색어 히스토리 드롭다운 구현

### DIFF
--- a/src/pages/search/apis/searchHistoryApi.ts
+++ b/src/pages/search/apis/searchHistoryApi.ts
@@ -1,0 +1,12 @@
+import type { SearchHistoryResponse } from '@/pages/search/types/searchTypes';
+
+import axiosInstance from '../../../shared/apis/axios';
+
+export const getSearchHistory = async (): Promise<string[]> => {
+    const { data } = await axiosInstance.get<SearchHistoryResponse>('/api/search/history');
+    return data.result ?? [];
+};
+
+export const addSearchHistory = async (query: string) => {
+    await axiosInstance.post('/api/search/history', { query });
+};

--- a/src/pages/search/components/SearchDropdown.tsx
+++ b/src/pages/search/components/SearchDropdown.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+
+type SearchDropdownProps = {
+    open: boolean;
+    inputValue: string;
+    items: string[];
+    onSelect: (q: string) => void;
+};
+
+export default function SearchDropdown({ open, inputValue, items, onSelect }: SearchDropdownProps) {
+    const filtered = useMemo(() => {
+        if (!inputValue) return items;
+        const v = inputValue.toLowerCase();
+        return items.filter((q) => q.toLowerCase().includes(v));
+    }, [items, inputValue]);
+
+    // 빈 상태 문구 상황에 따라 분기
+    const isFiltering = inputValue.length > 0; // 입력값 존재 여부
+    const emptyText = isFiltering ? '' : '최근 검색어가 아직 없어요.';
+
+    if (!open) return null; // 훅 호출 이후에 early return
+
+    return (
+        <div
+            role="listbox"
+            className="border-main absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border bg-white shadow-lg"
+        >
+            <div className="mt-1 flex items-center justify-between px-5 py-2">
+                <span className="text-14px-medium sm:text-16px-medium md:text-18px-medium lg:text-20px-medium text-main-70">
+                    {isFiltering ? '일치하는 검색어' : '최근 검색어'}
+                </span>
+            </div>
+
+            <ul className="max-h-72 overflow-y-auto py-1">
+                {filtered.length === 0 ? (
+                    <li className="text-14px-medium sm:text-16px-medium md:text-18px-medium lg:text-20px-medium text-black-50 px-5 py-1">
+                        {emptyText}
+                    </li>
+                ) : (
+                    filtered.map((q) => (
+                        <li key={q} className="px-2">
+                            <button
+                                onClick={() => onSelect(q)}
+                                className="text-14px-medium sm:text-16px-medium md:text-18px-medium lg:text-20px-medium hover:text-main-70 w-full cursor-pointer truncate rounded-lg px-3 py-2 text-left hover:bg-black/5"
+                            >
+                                {q}
+                            </button>
+                        </li>
+                    ))
+                )}
+            </ul>
+        </div>
+    );
+}

--- a/src/pages/search/hooks/useSearchHistory.ts
+++ b/src/pages/search/hooks/useSearchHistory.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { addSearchHistory, getSearchHistory } from '../apis/searchHistoryApi';
+
+export const useSearchHistory = (enabled: boolean) => {
+    const qc = useQueryClient();
+    const key = ['searchHistory'];
+
+    const historyQuery = useQuery({
+        queryKey: key,
+        queryFn: getSearchHistory,
+        enabled,
+        staleTime: 60_000,
+    });
+
+    const addMutation = useMutation({
+        mutationFn: (q: string) => addSearchHistory(q),
+        onSuccess: (_v, q) => {
+            qc.setQueryData<string[] | undefined>(key, (prev = []) => {
+                const dedup = [q, ...prev.filter((x) => x !== q)];
+                return dedup.slice(0, 10);
+            });
+        },
+    });
+
+    return {
+        items: historyQuery.data ?? [],
+        isLoading: historyQuery.isLoading,
+        refetch: historyQuery.refetch,
+        add: addMutation.mutate,
+    };
+};

--- a/src/pages/search/types/searchTypes.ts
+++ b/src/pages/search/types/searchTypes.ts
@@ -20,3 +20,11 @@ export interface SemanticSearchResponse {
     result: SemanticSearchResult;
     error: unknown | null;
 }
+
+export type SearchHistoryResponse = {
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: string[];
+    error: unknown | null;
+};

--- a/src/shared/components/Navbar/SearchBar.tsx
+++ b/src/shared/components/Navbar/SearchBar.tsx
@@ -1,35 +1,95 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import SearchDropdown from '@/pages/search/components/SearchDropdown';
 import SearchIcon from '@/shared/assets/search.svg?react';
+// 로그인 여부로 드롭다운 노출을 가드
+import { useAuth } from '@/shared/context/AuthContext';
 
 const SearchBar = () => {
     const navigate = useNavigate();
     const [keyword, setKeyword] = useState('');
 
+    // 드롭다운 열림/닫힘 제어
+    const [open, setOpen] = useState(false);
+    // 히스토리 목록
+    const [historyItems, setHistoryItems] = useState<string[]>([]);
+    // 바깥 클릭 감지
+    const wrapperRef = useRef<HTMLDivElement>(null);
+    // 로그인 사용자만 드롭다운 사용
+    const { isAuthenticated } = useAuth();
+
     const goToSearch = () => {
         if (keyword.trim()) {
             void navigate(`/search?query=${encodeURIComponent(keyword.trim())}`);
+
+            // 로그인된 경우에만 히스토리 업데이트
+            if (isAuthenticated) {
+                setHistoryItems((prev) => {
+                    const next = [keyword.trim(), ...prev.filter((x) => x !== keyword.trim())];
+                    return next.slice(0, 10);
+                });
+            }
+
+            // 검색 후 드롭다운 닫기
+            setOpen(false);
         }
     };
 
+    // 인풋 포커스 시 드롭다운 오픈 및 히스토리 불러오기 트리거
+    const handleFocus = () => {
+        if (!isAuthenticated) {
+            setOpen(false);
+            return;
+        }
+        setOpen(true);
+    };
+
+    // 컴포넌트 외부 클릭 시 드롭다운 닫기
+    useEffect(() => {
+        const onDocClick = (e: MouseEvent) => {
+            if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+        };
+        document.addEventListener('mousedown', onDocClick);
+        return () => document.removeEventListener('mousedown', onDocClick);
+    }, []);
+
     return (
-        <div className="border-main flex h-[35px] w-full gap-4 rounded-full border px-4 py-2 outline-none focus:ring-1 focus:ring-blue-400 md:h-[40px] md:max-w-[455px] md:min-w-[300px] lg:h-[45px] lg:max-w-[555px] lg:min-w-[400px]">
-            <input
-                type="text"
-                value={keyword}
-                onChange={(e) => setKeyword(e.target.value)}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                        void goToSearch();
-                    }
-                }}
-                placeholder="찾고싶은 기사가 있나요?"
-                className="placeholder: text-14px-medium sm:text-16px-medium md:text-18px-medium lg:text-20px-medium text-main-70 w-full pl-1 outline-none focus:outline-none"
-            />
-            <button onClick={() => void goToSearch()} className="hover:cursor-pointer">
-                <SearchIcon className="h-5 w-5 md:h-6 md:w-6 lg:h-7 lg:w-7" />
-            </button>
+        <div ref={wrapperRef} className="relative w-full md:max-w-[455px] lg:max-w-[555px]">
+            <div className="border-main flex h-[35px] w-full gap-4 rounded-full border px-4 py-2 outline-none focus:ring-1 focus:ring-blue-400 md:h-[40px] md:max-w-[455px] md:min-w-[300px] lg:h-[45px] lg:max-w-[555px] lg:min-w-[400px]">
+                <input
+                    type="text"
+                    value={keyword}
+                    onChange={(e) => setKeyword(e.target.value)}
+                    onFocus={handleFocus}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            void goToSearch();
+                        }
+                        if (e.key === 'Escape') {
+                            setOpen(false);
+                        }
+                    }}
+                    placeholder="찾고 싶은 기사가 있나요?"
+                    className="placeholder: text-14px-medium sm:text-16px-medium md:text-18px-medium lg:text-20px-medium text-main-70 w-full pl-1 outline-none focus:outline-none"
+                />
+                <button onClick={() => void goToSearch()} className="hover:cursor-pointer">
+                    <SearchIcon className="h-5 w-5 md:h-6 md:w-6 lg:h-7 lg:w-7" />
+                </button>
+            </div>
+            {/* 로그인된 사용자에게만 드롭다운 표시 */}
+            {isAuthenticated && (
+                <SearchDropdown
+                    open={open}
+                    inputValue={keyword}
+                    items={historyItems}
+                    onSelect={(q) => {
+                        setKeyword(q);
+                        void navigate(`/search?query=${encodeURIComponent(q)}`);
+                        setOpen(false);
+                    }}
+                />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## 📌 Summary
- close #147 
검색어 히스토리 드롭다운 UI 및 로직 구현


## 📝 Tasks
- SearchBar와 SearchDropdown 컴포넌트 연동
- 검색 인풋 포커스 시 최근 검색어 드롭다운 표시
- 검색 실행 시 검색어 히스토리 저장 및 최대 10개 유지
- 일치하는 검색어 없을 때/최근 검색어 없을 때 상태별 문구 분리
- 반응형 폰트 스타일을 SearchBar placeholder와 통일
- 드롭다운 외부 클릭 및 ESC 입력 시 닫히도록 처리

## ✅ PR Checklist (To Reviewer)
- [ ] 로그인/로그아웃 시 히스토리 동작이 정상적으로 되는지 확인
- [ ] 불필요한 렌더링이나 성능 이슈가 없는지 검토
- [ ] 반응형 UI 체크

## 📸 Screenshot
<img width="400" alt="image" src="https://github.com/user-attachments/assets/48595d43-a3d3-4704-821f-b11e82600b5f" />
