### PR TITLE
[Style] 공유 페이지 반응형 UI 구현

### DIFF
--- a/src/pages/article/SharePage.tsx
+++ b/src/pages/article/SharePage.tsx
@@ -28,55 +28,65 @@ const SharePage = () => {
 
     return (
         <div className="">
-            <div className="mx-auto flex max-w-[714px] min-w-2xl flex-col gap-4 px-6 py-6">
-                {/* FieldChips + 원문 링크 */}
-                <div className="flex items-center gap-4 overflow-x-auto whitespace-nowrap">
-                    <FieldChips label={data.category} />
-                    <div className="flex items-center gap-1">
-                        <ChainIcon />
-                        {data && (
-                            <a
-                                href={data.originalUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-20px-medium text-black-70 decoration-black-70 inline-block max-w-[525px] truncate align-bottom underline decoration-[0.5px] underline-offset-5"
-                                title={data.title}
-                            >
-                                원문링크
-                            </a>
-                        )}
+            <div className="mx-auto w-full max-w-[980px] px-4 py-6 sm:px-6 lg:px-8">
+                <div className="mx-auto flex w-full max-w-[714px] flex-col gap-4">
+                    {/* FieldChips + 원문 링크 */}
+                    <div className="flex items-center gap-3 overflow-x-auto whitespace-nowrap">
+                        <FieldChips label={data.category} />
+                        <div className="flex items-center gap-1">
+                            <ChainIcon />
+                            {data && (
+                                <a
+                                    href={data.originalUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-20px-medium text-black-70 decoration-black-70 inline-block max-w-[525px] truncate align-bottom underline decoration-[0.5px] underline-offset-5"
+                                    title={data.title}
+                                >
+                                    원문링크
+                                </a>
+                            )}
+                        </div>
                     </div>
-                </div>
 
-                {/* 제목 */}
-                <div className="grid w-full grid-cols-[1fr_auto] items-end gap-4">
-                    <div className="flex flex-col">
-                        <h1 className="text-36px-semibold leading-tight break-words">{data.title}</h1>
-                        {published && <span className="text-black-50 text-18px-medium mt-1">{published}</span>}
+                    {/* 제목 + 발행일 */}
+                    <div className="grid w-full grid-cols-1 items-end gap-2">
+                        <div className="flex flex-col">
+                            <h1 className="text-28px-semibold sm:text-32px-semibold lg:text-36px-semibold leading-tight break-words">
+                                {data.title}
+                            </h1>
+                            {published && (
+                                <span className="text-black-50 text-16px-medium sm:text-18px-medium mt-1">
+                                    {published}
+                                </span>
+                            )}
+                        </div>
                     </div>
-                </div>
 
-                <hr className="border-black-30 w-full border-t" />
+                    <hr className="border-black-30 w-full border-t" />
 
-                {/* 요약 */}
-                <div className="flex justify-center pt-4">
-                    <SummarizedNewsContainer
-                        summary={data.summary}
-                        articleId={data.articleId}
-                        title={data.title}
-                        image={''}
-                        showActions={false}
-                    />
-                </div>
+                    {/* 요약 */}
 
-                {/* 앱에서 보기 버튼 */}
-                <div className="flex justify-end">
-                    <Link
-                        to={appArticlePath}
-                        className="bg-main rounded-xl px-4 py-2 text-sm text-white hover:opacity-90"
-                    >
-                        스낵에서 보기
-                    </Link>
+                    <div className="flex justify-center pt-4">
+                        <SummarizedNewsContainer
+                            summary={data.summary}
+                            articleId={data.articleId}
+                            title={data.title}
+                            image={''}
+                            showActions={false}
+                        />
+                    </div>
+
+                    {/* 앱에서 보기 버튼 */}
+                    {/* 모바일: full-width 버튼, sm 이상: 우측 정렬 고정 폭 */}
+                    <div className="mt-2 flex w-full justify-end">
+                        <Link
+                            to={appArticlePath}
+                            className="bg-main text-14px-medium sm:text-16px-medium flex cursor-pointer items-center gap-1 rounded-xl px-3 py-2 text-white hover:opacity-90 sm:px-4"
+                        >
+                            🔗 스낵에서 보기
+                        </Link>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/shared/components/banner/TodayGreetingBanner/TodayGreetingBanner/TodayGreetingBanner.tsx
+++ b/src/shared/components/banner/TodayGreetingBanner/TodayGreetingBanner/TodayGreetingBanner.tsx
@@ -81,8 +81,8 @@ const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBanner
                     {/* 맞춤 피드 안내 */}
                     {hasNickname && (
                         <p className="text-18px-semibold sm:text-20px-semibold lg:text-24px-semibold mt-[6px] break-keep whitespace-normal text-black">
-                            <span>{effectiveNickname}님을 위한 </span>
-                            <span>오늘의 맞춤 피드를 보여드려요.</span>
+                            <span className="block sm:inline">{effectiveNickname}님을 위한 </span>
+                            <span className="block sm:inline">오늘의 맞춤 피드를 보여드려요.</span>
                         </p>
                     )}
                 </div>

--- a/src/shared/components/banner/TodayGreetingBanner/TodayGreetingBanner/TodayGreetingBanner.tsx
+++ b/src/shared/components/banner/TodayGreetingBanner/TodayGreetingBanner/TodayGreetingBanner.tsx
@@ -9,11 +9,17 @@ interface TodayGreetingBannerProps {
 
 const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBannerProps) => {
     const today = new Date();
-    const formatted = today.toLocaleDateString('ko-KR', {
+    const formattedWithWeekday = today.toLocaleDateString('ko-KR', {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
         weekday: 'long',
+    });
+
+    const formattedWithoutWeekday = today.toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
     });
 
     // AuthContext에서 사용자 정보 가져오기
@@ -59,12 +65,14 @@ const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBanner
                             {variant === 'home' ? (
                                 <>
                                     <span>오늘은 </span>
-                                    <span>{formatted}이에요.</span>
+                                    {/* 모바일에서는 요일 없는 날짜, sm 이상에서는 요일 포함 날짜 */}
+                                    <span className="sm:hidden">{formattedWithoutWeekday}이에요.</span>
+                                    <span className="hidden sm:inline">{formattedWithWeekday}이에요.</span>
                                 </>
                             ) : (
                                 <>
                                     <span>오늘은 </span>
-                                    <span>{formatted}이에요.</span>
+                                    <span>{formattedWithoutWeekday}이에요.</span>
                                 </>
                             )}
                         </p>
@@ -72,7 +80,7 @@ const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBanner
 
                     {/* 맞춤 피드 안내 */}
                     {hasNickname && (
-                        <p className="text-18px-semibold sm:text-20px-semibold lg:text-24px-semibold mt-[6px] text-black">
+                        <p className="text-18px-semibold sm:text-20px-semibold lg:text-24px-semibold mt-[6px] break-keep whitespace-normal text-black">
                             <span>{effectiveNickname}님을 위한 </span>
                             <span>오늘의 맞춤 피드를 보여드려요.</span>
                         </p>

--- a/src/shared/components/modal/loginModal/EmailLoginForm.tsx
+++ b/src/shared/components/modal/loginModal/EmailLoginForm.tsx
@@ -100,7 +100,7 @@ const EmailLoginForm = ({ onClose }: EmailLoginFormProps) => {
                 <button
                     onClick={handleLoginSubmit}
                     disabled={!isFormValid || isPending}
-                    className={`text-20px-medium h-[56px] w-full rounded-md py-3 text-white ${
+                    className={`text-20px-medium h-[56px] w-full rounded-md py-3 text-white transition hover:opacity-70 ${
                         isFormValid && !isPending ? 'bg-main cursor-pointer' : 'bg-black-30 cursor-not-allowed'
                     }`}
                 >

--- a/src/shared/components/modal/loginModal/LoginModal.tsx
+++ b/src/shared/components/modal/loginModal/LoginModal.tsx
@@ -99,6 +99,7 @@ const LoginModal = ({ isOpen, onClose }: ModalProps) => {
                                 textColor="text-black"
                                 width="320px"
                                 height="56px"
+                                borderColor="border-[1px] border-gray-500"
                                 onClick={handleGoogleLogin}
                             />
 
@@ -108,6 +109,7 @@ const LoginModal = ({ isOpen, onClose }: ModalProps) => {
                                 textColor="text-white"
                                 width="320px"
                                 height="56px"
+                                borderColor="border-none"
                                 onClick={handleEmailLoginClick}
                             />
                         </div>

--- a/src/shared/components/modal/loginModal/SocialLoginButton.tsx
+++ b/src/shared/components/modal/loginModal/SocialLoginButton.tsx
@@ -8,13 +8,23 @@ interface SocialLoginButtonProps {
     onClick?: () => void;
     width: string;
     height: string;
+    borderColor?: string;
 }
 
-const SocialLoginButton = ({ text, icon, bgColor, textColor, onClick, height, width }: SocialLoginButtonProps) => {
+const SocialLoginButton = ({
+    text,
+    icon,
+    bgColor,
+    textColor,
+    onClick,
+    height,
+    width,
+    borderColor = 'border-none',
+}: SocialLoginButtonProps) => {
     return (
         <button
             onClick={onClick}
-            className={`flex items-center justify-center gap-3 h-[${height}] w-[${width}] rounded-[8px] ${bgColor} ${textColor} cursor-pointer border-[1px] border-gray-500 transition hover:opacity-70`}
+            className={`flex items-center justify-center gap-3 h-[${height}] w-[${width}] ${borderColor} rounded-[8px] ${bgColor} ${textColor} cursor-pointer transition hover:opacity-70`}
         >
             {icon && <span> {icon}</span>}
             <span>{text}</span>


### PR DESCRIPTION
## 📌 Summary
- close #151 
- 공유 페이지 UI를 ArticlePage 반응형 스타일에 맞추어 수정
- 로그인 모달 스타일 개선
- 환영 배너 스타일을 개선

## 📝 Tasks
- 공유 페이지 레이아웃 반응형 구조 적용 (max-w, px, py 등 조정)
- 제목, 날짜, 요약 영역 타이포 반응형 크기 조정
- 스낵에서 보기 버튼 모바일 너비 및 패딩 최적화
- 환영 배너 모바일 환경 요일 속성 제거
- 환영 배너 (맞춤 페이지) 모바일 줄바꿈 형태 변경
- 이메일 로그인 모달 호버 속성 추가
- 로그인 모달 버튼 보더 속성 지정

## ✅ PR Checklist (To Reviewer)
- [ ] ArticlePage와 공유 페이지의 반응형 스타일 일관성이 맞는지 확인
- [ ] 환영 배너의 모바일 렌더링 결과가 의도대로 줄바꿈/요일 제거되는지 확인

## 📸 Screenshot
<img width="400" alt="KakaoTalk_20250819_192115592" src="https://github.com/user-attachments/assets/d07624e5-33dc-4a3c-ba18-64adabc05e82" />