### PR TITLE
[Style] 공유하기 모달과 토스트 알림 반응형 UI 구현

### DIFF
--- a/src/pages/article/components/GlossaryQuiz.tsx
+++ b/src/pages/article/components/GlossaryQuiz.tsx
@@ -32,16 +32,16 @@ const GlossaryQuiz = ({ articleId }: GlossaryQuizProps) => {
         try {
             if (reportType === 'term') {
                 await reportTerm(articleIdNumber);
-                setToastMessage('용어 신고가 접수되었습니다.');
+                setToastMessage('용어 신고 완료');
             } else {
                 await reportQuiz(articleIdNumber);
-                setToastMessage('퀴즈 해설 신고가 접수되었습니다.');
+                setToastMessage('퀴즈 신고 완료');
             }
         } catch (err: unknown) {
             if (axios.isAxiosError(err) && err.response?.status === 409) {
-                setToastMessage('이미 신고한 항목입니다.');
+                setToastMessage('이미 신고한 항목이에요.');
             } else {
-                setToastMessage('신고 처리 중 오류가 발생했습니다.');
+                setToastMessage('잠시 후 다시 시도해 주세요.');
             }
         } finally {
             setReportType(null);

--- a/src/shared/components/modal/ShareModal/CircleShareButton.tsx
+++ b/src/shared/components/modal/ShareModal/CircleShareButton.tsx
@@ -4,9 +4,9 @@ interface CircleShareButtonProps {
     icon: React.ReactNode;
     label: string;
     filled?: boolean;
-    bgColor?: string; // ex: 'bg-kakao-yellow'
-    borderColor?: string; // ex: 'border-naver-green'
-    textColor?: string; // ex: 'text-black-70'
+    bgColor?: string;
+    borderColor?: string;
+    textColor?: string;
     onClick?: () => void;
 }
 
@@ -23,14 +23,14 @@ function CircleShareButton({
     const finalStyle = filled ? bgColor : filledStyle;
 
     return (
-        <div className="flex w-[91px] flex-col items-center">
+        <div className="flex w-[72px] flex-col items-center sm:w-[91px]">
             <div
-                className={`flex h-[91px] w-[91px] cursor-pointer items-center justify-center rounded-full ${finalStyle}`}
+                className={`flex h-[80px] w-[80px] cursor-pointer items-center justify-center rounded-full sm:h-[91px] sm:w-[91px] ${finalStyle}`}
                 onClick={onClick}
             >
-                {icon}
+                <div className="flex h-[36px] w-[36px] items-center justify-center sm:h-[44px] sm:w-[44px]">{icon}</div>
             </div>
-            <span className={`text-18px-medium mt-[10px] ${textColor}`}>{label}</span>
+            <span className={`text-14px-medium sm:text-18px-medium mt-[6px] ${textColor}`}>{label}</span>
         </div>
     );
 }

--- a/src/shared/components/modal/ShareModal/ShareModal.tsx
+++ b/src/shared/components/modal/ShareModal/ShareModal.tsx
@@ -161,7 +161,7 @@ const ShareModal = ({ articleId, title, description, image, onClose }: ShareModa
                 <ShareToast
                     message={
                         status === 'ready'
-                            ? '링크가 복사되었습니다.'
+                            ? '링크가 복사되었어요!'
                             : status === 'loading'
                               ? '링크 생성 중입니다.'
                               : '이 기사는 공유할 수 없어요.'

--- a/src/shared/components/modal/ShareModal/ShareModal.tsx
+++ b/src/shared/components/modal/ShareModal/ShareModal.tsx
@@ -82,28 +82,38 @@ const ShareModal = ({ articleId, title, description, image, onClose }: ShareModa
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-10"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6 pb-[env(safe-area-inset-bottom,0px)] sm:py-10"
             onClick={(e) => {
                 if (modalRef.current && !modalRef.current.contains(e.target as Node)) onClose();
+            }}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onClose();
+                }
             }}
         >
             <div
                 ref={modalRef}
-                className="relative flex w-[600px] flex-col items-center rounded-[10px] bg-white px-[40px] py-[40px]"
+                className="relative flex max-h-[85vh] w-full max-w-[600px] flex-col items-center overflow-y-auto rounded-[12px] bg-white px-5 py-6 sm:px-10 sm:py-10"
             >
                 {/* 닫기 버튼 */}
                 <button
-                    className="absolute top-[12px] right-[8px] flex h-[35px] w-[35px] cursor-pointer items-center justify-center"
+                    className="absolute top-3 right-3 flex h-10 w-10 cursor-pointer items-center justify-center"
                     onClick={onClose}
                     aria-label="닫기"
                 >
                     <XIcon />
                 </button>
 
-                <div className="text-36px-semibold mt-[24px] mb-[36px] text-center">공유하기</div>
+                <div id="share-modal-title" className="text-24px-semibold sm:text-36px-semibold mt-2 text-center">
+                    공유하기
+                </div>
 
                 {/* 상태 메시지 */}
-                <div className="absolute top-[120px] flex items-center">
+                <div className="mb-4 flex min-h-[24px] items-center">
                     {status === 'loading' && <div className="text-black-70">링크를 생성 중입니다...</div>}
                     {status === 'forbidden' && (
                         <div className="text-danger/90">{errorMsg || '공유할 수 없는 기사입니다.'}</div>
@@ -114,7 +124,7 @@ const ShareModal = ({ articleId, title, description, image, onClose }: ShareModa
                 </div>
 
                 {/* 공유 아이콘 */}
-                <div className="mb-[20px] flex w-[401px] justify-between opacity-100">
+                <div className="mb-8 grid w-full grid-cols-3 justify-items-center gap-4 sm:flex sm:w-[401px] sm:justify-between">
                     <CircleShareButton
                         icon={<KakaoIcon width={44} height={44} />}
                         label="카카오톡"

--- a/src/shared/components/modal/ShareModal/ShareToast.tsx
+++ b/src/shared/components/modal/ShareModal/ShareToast.tsx
@@ -26,12 +26,13 @@ function ShareToast({ message, duration = 500, onDone }: ShareToastProps) {
 
     return (
         <div
-            className={`bg-black-70 fixed top-[85vh] left-1/2 z-[9999] flex h-[80px] w-[400px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-[8px] text-white shadow-md transition-opacity duration-300 ${
-                fadeOut ? 'opacity-0' : 'opacity-100'
-            }`}
+            className={`bg-black-70 fixed bottom-20 left-1/2 z-[9999] flex min-h-[48px] w-auto max-w-[320px] -translate-x-1/2 items-center justify-center rounded-lg px-6 py-3 pt-[env(safe-area-inset-bottom,0px)] pb-[env(safe-area-inset-bottom,0px)] text-center break-words whitespace-pre-line text-white shadow-lg transition-opacity duration-300 sm:max-w-[420px] sm:shadow-xl md:min-h-[56px] md:max-w-[520px] md:px-8 md:py-4 ${fadeOut ? 'opacity-0' : 'opacity-100'}`}
             role="alert"
+            aria-live="assertive"
         >
-            <span className="text-24px-semibold">{message}</span>
+            <span className="text-16px-semibold sm:text-20px-semibold md:text-24px-semibold flex flex-1 items-center justify-center text-center leading-normal break-words whitespace-normal">
+                {message}
+            </span>
         </div>
     );
 }

--- a/src/shared/components/modal/ShareModal/ShareToast.tsx
+++ b/src/shared/components/modal/ShareModal/ShareToast.tsx
@@ -26,7 +26,7 @@ function ShareToast({ message, duration = 500, onDone }: ShareToastProps) {
 
     return (
         <div
-            className={`bg-black-70 fixed bottom-20 left-1/2 z-[9999] flex min-h-[48px] w-auto max-w-[320px] -translate-x-1/2 items-center justify-center rounded-lg px-6 py-3 pt-[env(safe-area-inset-bottom,0px)] pb-[env(safe-area-inset-bottom,0px)] text-center break-words whitespace-pre-line text-white shadow-lg transition-opacity duration-300 sm:max-w-[420px] sm:shadow-xl md:min-h-[56px] md:max-w-[520px] md:px-8 md:py-4 ${fadeOut ? 'opacity-0' : 'opacity-100'}`}
+            className={`bg-black-70 fixed bottom-20 left-1/2 z-[9999] flex min-h-[48px] w-[90vw] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-lg px-6 py-3 pt-[env(safe-area-inset-bottom,0px)] pb-[env(safe-area-inset-bottom,0px)] text-center break-words whitespace-pre-line text-white shadow-lg transition-opacity duration-300 sm:max-w-[420px] sm:shadow-xl md:min-h-[56px] md:max-w-[520px] md:px-8 md:py-4 ${fadeOut ? 'opacity-0' : 'opacity-100'}`}
             role="alert"
             aria-live="assertive"
         >

--- a/src/shared/components/modal/loginModal/EmailLoginForm.tsx
+++ b/src/shared/components/modal/loginModal/EmailLoginForm.tsx
@@ -57,6 +57,13 @@ const EmailLoginForm = ({ onClose }: EmailLoginFormProps) => {
 
     const isFormValid = formData.email.trim() && formData.password.trim();
 
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            handleLoginSubmit();
+        }
+    };
+
     return (
         <>
             <div className="mt-12 text-center">
@@ -65,7 +72,7 @@ const EmailLoginForm = ({ onClose }: EmailLoginFormProps) => {
             </div>
 
             {/* 입력 필드 */}
-            <div className="mt-16 flex flex-col gap-2 px-12">
+            <div className="mt-16 flex flex-col gap-2 px-12" onKeyDown={handleKeyDown}>
                 <InputBox
                     label="이메일"
                     name="email"


### PR DESCRIPTION
## 📌 Summary
- close #159 
토스트 알림 및 공유 모달 반응형 UI 적용

## 📝 Tasks
- 토스트 알림 UI 반응형 변경
- 토스트 알림 문구 및 스타일 통일
- 공유 모달 크기 반응형 처리
- 공유 모달 아이콘 크기 반응형 처리
- 이메일 로그인 모달 Enter 키 동작 추가

## ✅ PR Checklist (To Reviewer)
- [ ] 반응형에서 토스트 알림이 정상적으로 중앙에 표시되는지 확인
- [ ] 공유 모달이 모바일/데스크톱에서 알맞은 크기로 노출되는지 확인
- [ ] 아이콘 크기가 원 안에서 비율에 맞게 조정되었는지 확인
- [ ] Enter 키로 이메일 로그인 시도가 정상적으로 동작하는지 확인

## 📸 Screenshot
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f720d06e-3747-43fc-937d-246d4fbd1d11" />
