### PR TITLE
[Feat] 온보딩 카드 + 맞춤피드/메인피드 배너 UI 개선

### DIFF
--- a/src/pages/custom-feed/CustomFeedPage.tsx
+++ b/src/pages/custom-feed/CustomFeedPage.tsx
@@ -75,8 +75,10 @@ const CustomFeedPage = () => {
             </div>
 
             {/* 온보딩 카드 */}
-            <div className="mb-20 flex justify-center sm:mb-24 lg:mb-[67px]">
-                <OnboardingCard />
+            <div className="mb-20 w-full sm:mb-24 lg:mb-[67px]">
+                <div className="-mx-4 mx-auto max-w-[1121px] px-5 sm:mx-0 sm:px-0">
+                    <OnboardingCard />
+                </div>
             </div>
 
             <div className="mx-auto max-w-[1151px]">

--- a/src/pages/custom-feed/CustomFeedPage.tsx
+++ b/src/pages/custom-feed/CustomFeedPage.tsx
@@ -76,9 +76,7 @@ const CustomFeedPage = () => {
 
             {/* 온보딩 카드 */}
             <div className="mb-20 w-full sm:mb-24 lg:mb-[67px]">
-                <div className="-mx-4 mx-auto max-w-[1121px] px-5 sm:mx-0 sm:px-0">
-                    <OnboardingCard />
-                </div>
+                <OnboardingCard />
             </div>
 
             <div className="mx-auto max-w-[1151px]">

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -49,7 +49,7 @@ const HomePage = () => {
     };
 
     useEffect(() => {
-        if (isCategoryEmpty) return; // ✅ 미선택이면 로깅 스킵
+        if (isCategoryEmpty) return; // 미선택이면 로깅 스킵
         console.log('현재 선택된 카테고리:', selectedCategories);
         console.log('API 로딩 상태:', isLoading);
     }, [selectedCategories, isLoading, isCategoryEmpty]);
@@ -57,7 +57,7 @@ const HomePage = () => {
     useEffect(() => {
         if (observerRef.current) observerRef.current.disconnect();
 
-        // ✅ 미선택이면 옵저버 설치 안 함
+        // 미선택이면 옵저버 설치 안 함
         if (isCategoryEmpty) return;
 
         observerRef.current = new IntersectionObserver(
@@ -78,7 +78,7 @@ const HomePage = () => {
 
     //  중복 제거(첫 등장 순서 유지)
     const articles = useMemo<MainFeedArticle[]>(() => {
-        if (isCategoryEmpty) return []; // ✅ 미선택이면 바로 빈 배열
+        if (isCategoryEmpty) return []; // 미선택이면 바로 빈 배열
         const seen = new Set<number>();
         const out: MainFeedArticle[] = [];
 
@@ -99,7 +99,7 @@ const HomePage = () => {
         return out;
     }, [data, isCategoryEmpty]);
 
-    // ✅ 카테고리 미선택 상태: API 호출 없이 안내 문구만 렌더
+    // 카테고리 미선택 상태: API 호출 없이 안내 문구만 렌더
     if (isCategoryEmpty) {
         return (
             <div className="min-h-screen py-8">
@@ -109,7 +109,7 @@ const HomePage = () => {
                 </div>
 
                 {/* 온보딩 카드 */}
-                <div className="mb-20 flex justify-center sm:mb-24 lg:mb-[67px]">
+                <div className="mb-20 sm:mb-24 lg:mb-[67px]">
                     <OnboardingCard />
                 </div>
 
@@ -144,7 +144,7 @@ const HomePage = () => {
             </div>
 
             {/* 온보딩 카드 */}
-            <div className="mb-20 flex justify-center sm:mb-24 lg:mb-[67px]">
+            <div className="mb-20 sm:mb-24 lg:mb-[67px]">
                 <OnboardingCard />
             </div>
 

--- a/src/shared/components/banner/TodayGreetingBanner/TodayGreetingBanner/TodayGreetingBanner.tsx
+++ b/src/shared/components/banner/TodayGreetingBanner/TodayGreetingBanner/TodayGreetingBanner.tsx
@@ -37,7 +37,7 @@ const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBanner
     return (
         <div className="flex w-full items-center justify-center">
             <div
-                className={`border-black-30 relative flex ${heightClass} w-full max-w-[1121px] items-center gap-6 rounded-2xl border bg-white px-4 shadow-[0_4px_10px_rgba(0,0,0,0.25)]`}
+                className={`border-black-30 relative flex ${heightClass} w-full max-w-[1121px] items-center gap-6 rounded-2xl border bg-white px-1.5 shadow-[0_4px_10px_rgba(0,0,0,0.25)]`}
             >
                 {/* 스프링 장식 */}
                 <div className="absolute top-1/2 -left-[8px] -translate-y-1/2">
@@ -58,7 +58,7 @@ const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBanner
                         <p
                             className={
                                 nickname
-                                    ? 'text-14px-medium sm:text-15px-medium lg:text-16px-medium'
+                                    ? 'text-16px-medium sm:text-18px-medium lg:text-16px-medium'
                                     : 'text-16px-medium sm:text-18px-medium lg:text-20px-medium'
                             }
                         >
@@ -80,9 +80,17 @@ const TodayGreetingBanner = ({ nickname, variant = 'home' }: TodayGreetingBanner
 
                     {/* 맞춤 피드 안내 */}
                     {hasNickname && (
-                        <p className="text-18px-semibold sm:text-20px-semibold lg:text-24px-semibold mt-[6px] break-keep whitespace-normal text-black">
-                            <span className="block sm:inline">{effectiveNickname}님을 위한 </span>
-                            <span className="block sm:inline">오늘의 맞춤 피드를 보여드려요.</span>
+                        <p className="text-18px-semibold sm:text-20px-semibold lg:text-24px-semibold mt-[6px] text-black">
+                            {/* 모바일 화면에서만 보이는 문구 */}
+                            <span className="break-keep whitespace-normal sm:hidden">
+                                {effectiveNickname}님의 맞춤 뉴스를 확인해 보세요.
+                            </span>
+
+                            {/* 태블릿 이상의 화면에서만 보이는 문구 */}
+                            <span className="hidden sm:block">
+                                <span className="break-keep whitespace-normal">{effectiveNickname}님을 위한 </span>
+                                <span className="break-keep whitespace-normal">오늘의 맞춤 피드를 보여드려요.</span>
+                            </span>
                         </p>
                     )}
                 </div>

--- a/src/shared/components/card/OnboardingCard.tsx
+++ b/src/shared/components/card/OnboardingCard.tsx
@@ -41,7 +41,7 @@ export default function OnboardingCard() {
     }, [embla]);
 
     return (
-        <section className="flex h-[250px] max-w-full flex-col items-center space-y-6 sm:h-[260px] sm:max-w-[1000px] sm:space-y-8 sm:px-6 lg:h-[322px] lg:max-w-[1135px] lg:space-y-8 lg:px-8">
+        <section className="mx-auto flex h-[250px] max-w-full flex-col items-center space-y-6 sm:h-[260px] sm:max-w-[1000px] sm:space-y-8 sm:px-6 lg:h-[322px] lg:max-w-[1135px] lg:space-y-8 lg:px-8">
             {/* 캐러셀 박스 */}
             <div className="relative w-full">
                 {/* 좌우 버튼 - 태블릿+에서만 표시 */}


### PR DESCRIPTION
## 📌 Summary
- close #163 
- 온보딩 카드 캐러셀의 모든 화면(모바일, 태블릿, 데스크톱)에서의 중앙 정렬 문제 해결
- 맞춤피드/메인피드 배너의 모바일 UI를 개선하여 가독성과 사용자 경험 향상

## 📝 Tasks
- OnboardingCard 컴포넌트 개선
    - 컴포넌트 자체에 mx-auto 스타일을 추가하여, 부모 요소의 영향을 받지 않고 스스로 중앙 정렬되도록 수정

- 맞춤피드/메인피드 페이지 코드 수정

    - OnboardingCard를 감싸던 불필요한 div 컨테이너와 flex, mx, px 같은 스타일을 제거하여, 컴포넌트 간의 스타일 충돌을 방지

- `TodayGreetingBanner` 컴포넌트 개선

    - 모바일 환경에서 배너의 좌우 패딩을 줄여 더 넓은 공간을 활용하도록 수정
    - 맞춤피드 배너의 문구를 모바일 환경에 최적화된 짧은 문장으로 변경하고, 단어 단위로 자연스럽게 줄바꿈되도록 개선

## ✅ PR Checklist (To Reviewer)
- [ ] 모바일 환경에서 온보딩 카드 캐러셀이 화면 중앙에 올바르게 정렬되는지 확인
- [ ] 모바일 환경에서 `TodayGreetingBanner`의 좌우 여백이 줄어들고, 문구가 자연스럽게 줄바꿈되는지 확인
- [ ] 다른 페이지(메인피드)에서도 `OnboardingCard`가 올바르게 렌더링되는지 확인 

## 📸 Screenshot
<img width="241" height="401" alt="image" src="https://github.com/user-attachments/assets/1e6d5b12-4d58-4536-8cca-a33a89ded3e9" />

