### PR TITLE
[Feat] 메모 자동 저장 토스트 알림 기능 추가

### DIFF
--- a/src/shared/components/modal/MemoPad/MemoPad.tsx
+++ b/src/shared/components/modal/MemoPad/MemoPad.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useMemoManagement } from '@/pages/article/hooks/useMemoManagement';
+import ShareToast from '@/shared/components/modal/ShareModal/ShareToast';
 
 interface MemoPadProps {
     articleId: string;
 }
 
 const MemoPad = ({ articleId }: MemoPadProps) => {
-    // 메모 관리 훅 사용
     const {
         memos,
         isLoading,
@@ -21,16 +21,13 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
         clearError,
     } = useMemoManagement({ articleId });
 
-    // 자동 저장을 위한 타이머 ref
     const autoSaveTimerRef = useRef<number | null>(null);
-
-    // 현재 편집 중인 메모 ID (새 메모는 0)
     const [currentEditingMemoId, setCurrentEditingMemoId] = useState<number>(0);
-
-    // 현재 textarea 내용
     const [currentContent, setCurrentContent] = useState<string>('');
 
-    // 자동 저장 타이머 정리 함수
+    // 토스트 표시 상태 추가
+    const [showToast, setShowToast] = useState(false);
+
     const clearAutoSaveTimer = useCallback(() => {
         if (autoSaveTimerRef.current) {
             window.clearTimeout(autoSaveTimerRef.current);
@@ -38,26 +35,26 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
         }
     }, []);
 
-    // 자동 저장 실행 함수
     const executeAutoSave = useCallback(
         async (memoId: number, content: string) => {
             try {
                 if (content.trim().length === 0) {
-                    // 내용이 비어있으면 삭제 (기존 메모만)
                     if (memoId > 0) {
                         await removeMemo(memoId);
                         setCurrentEditingMemoId(0);
                         setCurrentContent('');
                     }
                 } else if (memoId === 0) {
-                    // 새 메모 생성 (내용이 있을 때만)
                     const newMemo = await createNewMemo(content);
                     if (newMemo) {
                         setCurrentEditingMemoId(newMemo.memoId);
                     }
+                    // 새 메모 생성 시 토스트 표시
+                    setShowToast(true);
                 } else {
-                    // 기존 메모 수정
                     await updateExistingMemo(memoId, content);
+                    // 기존 메모 수정 시 토스트 표시
+                    setShowToast(true);
                 }
             } catch (error) {
                 console.error('자동 저장 실패:', error);
@@ -66,18 +63,10 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
         [createNewMemo, updateExistingMemo, removeMemo]
     );
 
-    // 자동 저장 타이머 설정
     const startAutoSaveTimer = useCallback(
         (memoId: number, content: string): void => {
-            // 빈 내용이고 새 메모인 경우 타이머 시작하지 않음
-            if (content.trim().length === 0 && memoId === 0) {
-                return;
-            }
-
-            // 기존 타이머 정리
+            if (content.trim().length === 0 && memoId === 0) return;
             clearAutoSaveTimer();
-
-            // 새 타이머 설정 (3초 후 자동 저장)
             autoSaveTimerRef.current = window.setTimeout(() => {
                 void executeAutoSave(memoId, content);
             }, 3000);
@@ -85,12 +74,9 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
         [clearAutoSaveTimer, executeAutoSave]
     );
 
-    // textarea 내용 변경 핸들러
     const handleContentChange = useCallback(
         (content: string): void => {
             setCurrentContent(content);
-
-            // 빈 내용이거나 사용자가 실제로 입력한 경우에만 자동 저장 타이머 시작
             if (content.trim().length > 0 || currentEditingMemoId > 0) {
                 startAutoSaveTimer(currentEditingMemoId, content);
             }
@@ -98,10 +84,8 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
         [currentEditingMemoId, startAutoSaveTimer]
     );
 
-    // 초기 메모 설정
     const initializeMemo = useCallback(() => {
-        if (currentEditingMemoId > 0) return; // 이미 편집 중이면 유지
-
+        if (currentEditingMemoId > 0) return;
         if (memos.length > 0 && !isLoading) {
             const firstMemo = memos[0];
             setCurrentContent(firstMemo.content);
@@ -112,17 +96,14 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
         }
     }, [memos, isLoading, currentEditingMemoId]);
 
-    // 컴포넌트 마운트 시 초기 메모 설정
     useEffect(() => {
         initializeMemo();
     }, [initializeMemo]);
 
-    // 컴포넌트 언마운트 시 타이머 정리
     useEffect(() => {
         return clearAutoSaveTimer;
     }, [clearAutoSaveTimer]);
 
-    // 에러 메시지 자동 숨김
     useEffect(() => {
         if (error) {
             const timer = window.setTimeout(() => {
@@ -130,11 +111,9 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
             }, 5000);
             return () => window.clearTimeout(timer);
         }
-        // error가 false일 때는 cleanup 함수가 필요 없으므로 undefined 반환
         return undefined;
     }, [error, clearError]);
 
-    // 로딩 상태에 따른 비활성화
     const isDisabled = isLoading || isCreating || isUpdating || isDeleting;
 
     return (
@@ -142,7 +121,6 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
             <div className="text-28px-medium lg:text-36px-medium m-2 justify-center lg:mb-4">메모장</div>
             <div className="bg-main-70 mb-6 h-[2px] w-[260px] md:w-[420px] lg:w-[300px]"></div>
 
-            {/* 메모 입력 영역 */}
             <div className="border-black-30 mb-2 h-[180px] w-[260px] gap-4 rounded-[16px] border-[2px] px-2 py-3 md:mb-4 md:h-[200px] md:w-[420px] lg:mb-0 lg:h-[280px] lg:w-[300px]">
                 <textarea
                     placeholder="메모를 입력하세요..."
@@ -152,7 +130,6 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
                     className="text-18px-medium placeholder-black-70 h-full w-full resize-none overflow-y-scroll bg-[linear-gradient(to_bottom,transparent_31px,#94a3b8_31.5px,transparent_32px)] bg-[length:calc(100%-10px)_32px] [background-attachment:local] bg-repeat-y pr-[12px] text-[16px] leading-[32px] outline-none disabled:opacity-50"
                 />
 
-                {/* 상태 메시지 영역 */}
                 <div className="text-14px-medium mt-3 text-center">
                     {isLoading && <div className="text-blue-600">메모를 불러오고 있습니다...</div>}
                     {error && <div className="text-red-600">저장되지 않았습니다.</div>}
@@ -161,6 +138,11 @@ const MemoPad = ({ articleId }: MemoPadProps) => {
                     {isDeleting && <div className="text-orange-600">삭제 중...</div>}
                 </div>
             </div>
+
+            {/* 자동 저장 성공 시 토스트 표시 */}
+            {showToast && (
+                <ShareToast message="메모가 자동 저장되었습니다." duration={800} onDone={() => setShowToast(false)} />
+            )}
         </div>
     );
 };

--- a/src/shared/components/modal/ShareModal/ShareModal.tsx
+++ b/src/shared/components/modal/ShareModal/ShareModal.tsx
@@ -5,13 +5,13 @@ import XIcon from '@/shared/assets/icons/close-x.svg?react';
 import GmailIcon from '@/shared/assets/icons/logo-gmail.svg?react';
 import KakaoIcon from '@/shared/assets/icons/logo-kakao.svg?react';
 import TwitterIcon from '@/shared/assets/icons/logo-x.svg?react';
+import ShareToast from '@/shared/components/modal/ShareModal/ShareToast';
 import { handleGmailShare } from '@/shared/utils/gmailShare';
 import { handleKakaoShare } from '@/shared/utils/kakaoShare';
 import { handleTwitterShare } from '@/shared/utils/twitterShare';
 
 import CircleShareButton from './CircleShareButton';
 import CopyLinkBox from './CopyLinkBox';
-import ShareToast from './ShareToast';
 
 interface ShareModalProps {
     articleId: number;


### PR DESCRIPTION
## 📌 Summary
- close #193 
메모 자동 저장(create/update) 시 사용자에게 저장 완료를 즉시 알리는 토스트(ShareToast) 노출을 추가하고, 중복 노출 방지를 위해 단일 상태로 제어했습니다.

## 📝 Tasks
 - [ ] ShareToast 임포트 및 토스트 상태(showToast) 추가
 - [ ] 자동 저장 로직(executeAutoSave) 내 신규 생성/수정 성공 시 토스트 트리거
 - [ ] 불필요한 토스트 스팸 방지: 상태 기반 단일 토스트 표출 및 onDone으로 자동 해제

## ✅ PR Checklist (To Reviewer)
- [ ] 토스트 문구/톤 확인: “메모가 자동 저장되었습니다.”
- [ ] 토스트 지속 시간(800ms) 적정성 검토
- [ ] 연속 타이핑 → 디바운스(3s) → 단일 토스트만 노출되는지 확인
- [ ] 모바일/데스크톱 뷰(지정된 Tailwind 브레이크포인트)에서 레이아웃 이상 없음
- [ ] ~~로컬 테스트 완료 -> 서버로 테스트 전~~ 실제 서버로 테스트 완료 


## 📸 Screenshot
-
