### PR TITLE
[Feat] default 카테고리 전체 선택으로 변경

### DIFF
--- a/src/shared/constants/categoryConstants.ts
+++ b/src/shared/constants/categoryConstants.ts
@@ -19,7 +19,7 @@ export const CATEGORY_MAP: Record<ApiCategory, ArticleCardCategory> = {
 export const mapApiCategoryToCardCategory = (apiCategory: string): ArticleCardCategory =>
     (CATEGORY_MAP as Record<string, ArticleCardCategory>)[apiCategory] ?? '기타';
 
-export const DEFAULT_SELECTED_CATEGORIES = ['정치'] as const;
+export const DEFAULT_SELECTED_CATEGORIES = ['정치', '경제', '사회', '생활/문화', '세계', 'IT/과학'] as const;
 
 export const CATEGORY_CODE_TO_KO: Record<string, ApiCategory> = {
     '100': '정치',


### PR DESCRIPTION
## 📌 Summary
- close #195 
홈 화면 최초 진입 시 모든 카테고리 토글이 선택된 상태로 표시되도록 변경했습니다.

## 📝 Tasks
- DEFAULT_SELECTED_CATEGORIES 상수를 API_FILTERABLE_CATEGORIES 전체로 초기화
- 첫 로드 시 모든 기사 카테고리가 표시되도록 반영

## ✅ PR Checklist (To Reviewer)
- [ ] 첫 진입 시 모든 카테고리 토글이 활성화(파란색) 상태로 보이는지 확인
- [ ] 선택 해제 시 정상적으로 필터링 및 API 호출 제어되는지 확인


## 📸 Screenshot
-